### PR TITLE
CASMINST-2931: Add check of cfs-state-reporter to cmsdev cfs test

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -5,7 +5,7 @@ ipvsadm=1.29-4.3.1
 python3-boto3=1.14.40-7.11.1
 platform-utils=0.2.1-1
 hms-ct-test-crayctldeploy=1.6.3-1
-cray-cmstools-crayctldeploy=1.0.17-1
+cray-cmstools-crayctldeploy=1.0.22-1
 rpm-build=4.14.1-20.3
 
 # COS


### PR DESCRIPTION
This updates to a cms-tools RPM which includes the new cfs-state-reporter checks, described in this PR: https://github.com/Cray-HPE/cms-tools/pull/7

I tested it on several csm-1.0 systems and verified that it works as expected.