### PR TITLE
CASMINST-3044: Get docs-csm from algol60 (csm-1.0)

### DIFF
--- a/packages/extra.packages
+++ b/packages/extra.packages
@@ -7,5 +7,5 @@ shasta-authorization-module=1.4.6-20210611143046_2ef0782
 cray-switchboard=1.2.2-20210615160128_b7454e2
 cray-uai-util=1.0.11-20210518075246_fb9d9c8
 
-docs-csm-install=1.10.27-20210701163842_7f1dcf0
+docs-csm=1.10.54-1
 csm-install-workarounds=0.1.11-20210622150140_49a352b


### PR DESCRIPTION
Now that docs-csm is building on github and publishing to algol60, let's update the manifest to get it from there.