### PR TITLE
CASMINST-3044: Get docs-csm from algol60 (csm-1.1)

### DIFF
--- a/packages/extra.packages
+++ b/packages/extra.packages
@@ -7,5 +7,5 @@ shasta-authorization-module=1.5.2-1
 cray-switchboard=1.2.2-20210615160128_b7454e2
 cray-uai-util=1.0.11-20210518075246_fb9d9c8
 
-docs-csm-install=1.10.27-20210701163842_e096dbf
+docs-csm=1.11.0-1
 csm-install-workarounds=0.1.11-20210524155302_10173aa


### PR DESCRIPTION
Now that docs-csm is building on github and publishing to algol60, let's update the manifest to get it from there.