### PR TITLE
Update csm-install-workarounds RPM for csm-1.2 to one with the new version

### DIFF
--- a/packages/extra.packages
+++ b/packages/extra.packages
@@ -8,4 +8,4 @@ cray-switchboard=1.2.2-20210615160128_b7454e2
 cray-uai-util=1.0.11-20210518075246_fb9d9c8
 
 docs-csm=1.12.0-1
-csm-install-workarounds=0.1.11-20210524155322_10173aa
+csm-install-workarounds=1.12.0-20210910134452_a829d71


### PR DESCRIPTION
This PR just updates the version of the csm-install-workarounds RPM to match the new versioning system. The content of the RPM is identical.