### PR TITLE
CASMINST-3082: Enable cfs-state-reporter test on storage NCNs

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -5,7 +5,7 @@ ipvsadm=1.29-4.3.1
 python3-boto3=1.17.9-19.1
 platform-utils=1.1.0-1
 hms-ct-test-crayctldeploy=1.8.4-1
-cray-cmstools-crayctldeploy=1.2.74-1
+cray-cmstools-crayctldeploy=1.2.77-1
 rpm-build=4.14.3-37.2
 
 # COS


### PR DESCRIPTION
Now that spire has been enabled on storage NCNs, this enables the cfs-state-reporter health check test to validate storage NCNs as well. Full details in this PR:
https://github.com/Cray-HPE/cms-tools/pull/9

This is ready for merge when approved.