### PR TITLE
CASMINST-3180: Services Repos

### DIFF
--- a/scripts/rpm-functions.sh
+++ b/scripts/rpm-functions.sh
@@ -235,6 +235,4 @@ function cleanup-all-repos() {
   zypper -n removerepo -a
   echo "Running a zypper clean"
   zypper -n clean --all
-  echo "Disabling remote zypper service repos"
-  zypper ms --remote --disable
 }


### PR DESCRIPTION
- Removes a line that disables services repos because they are deleted earlier in the build process. 