### PR TITLE
Install the new pit-init RPM, replacing the baked in scripts on the I…

### DIFF
--- a/packages/cray-pre-install-toolkit/metal.packages
+++ b/packages/cray-pre-install-toolkit/metal.packages
@@ -3,3 +3,4 @@ ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.0.7-1
 metal-net-scripts=0.0.2-1
+pit-init=1.2.2-1


### PR DESCRIPTION
Another PR will come after this merges to release/1.2 and main, that upcoming PR will be for removing pit-init from the LiveCD's [`config.xml`](https://github.com/Cray-HPE/cray-pre-install-toolkit/blob/main/suse/x86_64/cray-pre-install-toolkit-sle15sp3/config.xml#L137).