### PR TITLE
Updated hms-ct-test to use a non root container

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -4,7 +4,7 @@ manifestgen=1.3.3-1~development~1955191
 ipvsadm=1.29-4.3.1
 python3-boto3=1.17.9-19.1
 platform-utils=1.1.0-1
-hms-ct-test-crayctldeploy=1.8.4-1
+hms-ct-test-crayctldeploy=1.8.5-1
 cray-cmstools-crayctldeploy=1.2.77-1
 rpm-build=4.14.3-37.2
 


### PR DESCRIPTION
# Issues and Related PRs

* Resolves CASMHMS-5200 for epic CASM-2538 in csm-1.2.
* Should merge with the following PR: https://stash.us.cray.com/projects/CSM/repos/csm/pull-requests/1391

# Testing

The tests logs are on the PRs. The PRs are in listed in CASM-2538

# Risks and Mitigations

There is risk is low. This can only affect the HMS test scripts.