### PR TITLE
CASMCMS-7645: Update RPMs to match csm repo version changes for csm-1.2

### DIFF
--- a/packages/compute-node.packages
+++ b/packages/compute-node.packages
@@ -1,5 +1,5 @@
-craycli=0.40.20-20210812135921_5922b54
-cray-switchboard=1.2.2-20210615160128_b7454e2
-cray-uai-util=1.0.11-20210518075246_fb9d9c8
-cfs-state-reporter=1.7.36-1
-cfs-trust=1.3.71-1
+craycli=0.41.8-1
+cray-switchboard=1.2.3-1
+cray-uai-util=1.0.13-1
+cfs-state-reporter=1.7.50-1
+cfs-trust=1.3.87-1

--- a/packages/extra.packages
+++ b/packages/extra.packages
@@ -1,11 +1,11 @@
 cf-ca-cert-config-framework=2.3.5-1
-cfs-trust=1.3.71-1
-csm-ssh-keys=1.3.5-1
-csm-ssh-keys-roles=1.3.5-1
+cfs-trust=1.3.87-1
+csm-ssh-keys=1.3.79-1
+csm-ssh-keys-roles=1.3.79-1
 shasta-authorization-module=1.6.2-1
 
-cray-switchboard=1.2.2-20210615160128_b7454e2
-cray-uai-util=1.0.11-20210518075246_fb9d9c8
+cray-switchboard=1.2.3-1
+cray-uai-util=1.0.13-1
 
-docs-csm=1.12.0-1
+docs-csm=1.12.7-1
 csm-install-workarounds=1.12.1-1

--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -5,7 +5,7 @@ ipvsadm=1.29-4.3.1
 python3-boto3=1.17.9-19.1
 platform-utils=1.2.1-1
 hms-ct-test-crayctldeploy=1.8.5-1
-cray-cmstools-crayctldeploy=1.2.102-1
+cray-cmstools-crayctldeploy=1.2.105-1
 rpm-build=4.14.3-37.2
 
 # COS

--- a/packages/node-image-non-compute-common/cms.packages
+++ b/packages/node-image-non-compute-common/cms.packages
@@ -1,3 +1,3 @@
 #CMS
-cfs-state-reporter=1.7.36-1
-cfs-trust=1.3.79-1
+cfs-state-reporter=1.7.50-1
+cfs-trust=1.3.87-1


### PR DESCRIPTION
This PR does two things:
1) Updates RPM versions to match version changes for CASMCMS-7645 for csm-1.2
2) Updates RPM versions for cases where the csm repo and csm-rpms repo have become out of sync in terms of versions

This is ready to be merged pending approvals.