### PR TITLE
CASMINST-3426 Update to latest hpe-csm-scripts RPM to add missing HSM script main

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -5,7 +5,7 @@ cray-heartbeat=1.2.2-2.1_6.11__gf6fd0bd.shasta
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
 craycli=0.41.8-1
 csm-node-identity=1.0.18-1
-hpe-csm-scripts=0.0.20-20210728163955_8e17129
+hpe-csm-scripts=0.0.28-20211005110449_38c41f8
 
 # CSM Testing Utils
 goss-servers=1.8.17-1

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -23,5 +23,6 @@ http://car.dev.cray.com/artifactory/sdu/SSA/sle15_sp2_ncn/noarch/release/sdu-1.1
 http://car.dev.cray.com/artifactory/sdu/SSA/sle15_sp2_ncn/x86_64/release/sdu-1.1/                      cray-sdu-sle-15sp2-x86_64-sdu-1.1                 --no-gpgcheck -p 89                   cray/sdu/sle-15sp2/x86_64
 
 https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/hpe/                                        x86_64/canu                                       --no-gpgcheck -p 89                   cray/csm/sle-15sp3/x86_64
+https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/release/                                    cray-csm-rpm-stable-local-release                 --no-gpgcheck -p 89                   cray/csm/rpm/stable/local/release
 
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/                                   cray-algol60-csm-rpms-stable	                     --no-gpgcheck -p 69	               cray/csm/sle-15sp3
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/                             cray-algol60-csm-rpms-stable                      --no-gpgcheck -p 69                   cray/csm/sle-15sp3


### PR DESCRIPTION
### Summary and Scope

This change updates the hpe-csm-scripts RPM to the latest version to add the missing run_hms_ct_tests.sh automation script to installs. The RPM artifact is now published to a different repository than it was previously, so add the new directory to cray.repos such that the latest RPM version can be found.

### Issues and Related PRs

* CASMINST-3426 in main.

### Testing

Ran wget locally with the new URL followed by the new RPM name/version and verified that it was retrieved successfully.

### Risks and Mitigations

Need this PR reviewed to ensure that the new directory entry for cray.repos is specified correctly.