### PR TITLE
CASMPET-5125 main : Release csm-testing v1.8.19

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.20-20210728163955_8e17129
 
 # CSM Testing Utils
-goss-servers=1.8.17-1
+goss-servers=1.8.19-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
Releases the following changes for main
* CASMPET-4997 : AUTOMATION: refactor goss-k8s-resolve-external-dns.yaml for airgapped
* CASMPET-4688 : Create a spire goss test suite
* CASMINST-3423 : WASP: "Bond Members Have Links" goss test failure
* CASMINST-3424 : WASP: "Default Gateway Same as CAN Gateway" goss test failure
* CASMINST-3390 : TESTS: BIOS Baseline and Firmware and BIOS versions tests are failing in 1.2