### PR TITLE
CASMPET-5139-1.2 : Includes CASMPET-5132 & CASMPET-5128

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.28-20211005110449_38c41f8
 
 # CSM Testing Utils
-goss-servers=1.8.22-1
+goss-servers=1.8.23-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
Update to packages to pull in v1.8.23 released version of goss-servers
This pulls in changes for
* CASMPET-5132 : Create a no-wipe test
* CASMPET-5128 : Remove spire healthcheck from PIT node storage check