### PR TITLE
CASMNET-1008:  Add CHN pools to metallb config

### DIFF
--- a/packages/cray-pre-install-toolkit/metal.packages
+++ b/packages/cray-pre-install-toolkit/metal.packages
@@ -1,4 +1,4 @@
-cray-site-init=1.9.10-1
+cray-site-init=1.9.12-1
 ilorest=3.2.3-1
 kernel-default=5.3.18-59.19.1
 kernel-mft-mlnx-kmp-default=4.17.0_k5.3.18_57-1.sles15sp3


### PR DESCRIPTION
## Summary and Scope

Adds CHN network to CSI generation.

## Issues and Related PRs

* Resolves https://connect.us.cray.com/jira/browse/CASMNET-1008

## Testing

### Tested on:

  * wasp

### Test description:

Tested on wasp by running csi config init with various different system_config.yaml files.
* with no CHN inputs
* with chn-cidr but no static or dynamic pools
* with only static pool
* with only dynamic pool
* with both static and dynamic pools
I inspected the files generated by CSI; in particular sls_input_file.json, pit-files, metallb.yaml

## Risks and Mitigations

This is a little risky in that it introduces new configuration. This risk is expected at this point as we continue integration of CHN.


## Pull Request Checklist

- [ x] Version number(s) incremented, if applicable
- [ x] Copyrights updated
- [x ] License file intact
- [x ] Target branch correct
- [ x] CHANGELOG.md updated
- [x ] Testing is appropriate and complete, if applicable
- [x ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable



