### PR TITLE
CASMPET-5160 main : Release csm-testing for CASMPET-5003 and CASMINST-3526

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.28-20211005110449_38c41f8
 
 # CSM Testing Utils
-goss-servers=1.8.26-1
+goss-servers=1.8.28-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
## Summary and Scope
Releases csm-testing which includes changes for csm-1.2

CASMPET-5003 : AUTOMATION: Refactor goss-k8s-monitoring-url.yaml for Bi-CAN
CASMINST-3526 : Drax: Velero backup failed during automated goss test in k8 nodes