### PR TITLE
CASMINST-3546 1.2 : csi pit validate for k8s has failed

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.28-20211005110449_38c41f8
 
 # CSM Testing Utils
-goss-servers=1.8.28-1
+goss-servers=1.8.29-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
Resolves
* CASMINST-3546 : csi pit validate for k8s has failed