### PR TITLE
CASMPET-4873:  Generate metallb config in customizations.yaml

### DIFF
--- a/packages/cray-pre-install-toolkit/metal.packages
+++ b/packages/cray-pre-install-toolkit/metal.packages
@@ -1,4 +1,4 @@
-cray-site-init=1.10.2-1
+cray-site-init=1.10.3-1
 ilorest=3.2.3-1
 kernel-default=5.3.18-59.19.1
 kernel-mft-mlnx-kmp-default=4.17.0_k5.3.18_57-1.sles15sp3


### PR DESCRIPTION
## Summary and Scope

Generates the metalLB config in the customizations.yaml so the config map can get rendered into the new metallb chart.
This will still generate the metallb.yaml as well until we confirm that the config map within the chart is fully working.

This is backwards compatible.

## Issues and Related PRs

* Resolves [CASMPET-4873](https://connect.us.cray.com/jira/browse/CASMPET-4873)

### Tested on:

  * surtur

### Test description:

Generated files with CSI and verified that both the metallb.yaml and customizations.yaml look correct.
I tested both with and without the CHN network defined.
 
 
## Risks and Mitigations
 
Low risk since we are still generating the metallb.yaml as well.  That can be a fallback.


