### PR TITLE
CASMINST-3603: Bump goss-servers to 1.8.34

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.29-1
 
 # CSM Testing Utils
-goss-servers=1.8.33-1
+goss-servers=1.8.34-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
This is the release: https://github.com/Cray-HPE/csm-testing/releases

This includes the fix for:

* CASMINST-3603: ncnhealthchecks failed for goss k8 monitoring URL test case

(cherry picked from commit 225bed242cbf367ff2245fde9b6f5e62dcb8ed40)
