### PR TITLE
CASMTRIAGE-2732 - Fix barebones image boot test script.

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -4,7 +4,7 @@ manifestgen=1.3.4-1~development~bbba190
 ipvsadm=1.29-4.3.1
 python3-boto3=1.17.9-19.1
 platform-utils=1.2.2-1
-cray-cmstools-crayctldeploy=1.2.107-1
+cray-cmstools-crayctldeploy=1.2.109-1
 rpm-build=4.14.3-37.2
 
 # COS


### PR DESCRIPTION
## Summary and Scope
This fixes a bug in the barebones image boot test script where the user input for which compute node to use for the test was being ignored.  Without this fix a random compute node was always used, with this fix the user may specify which node to use.

## Issues and Related PRs
Code PR: https://github.com/Cray-HPE/cms-tools/pull/18

* Resolves [CASMTRIAGE-2732](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2732)

## Testing
### Tested on:
  * `Wasp`

### Test description:

I loaded the modified script on wasp and disabled that portion of the script that actually initiates the boot, but kept the argument processing and finding a compute node to use for the test. I verified that when a node is specified on the command line it now flows through to the function that looks for an available node. I also tested scenarios where there is nothing passed in and where an incorrect node xname is used.

Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
Were continuous integration tests run? If not, why? N - this is a test script
Was upgrade tested? If not, why? N - this is a test script installed via rpm.
Was downgrade tested? If not, why? N - this is a test script installed via rpm.
Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

This is a low risk change - it just modifies handling an optional input argument to a test script. It will not impact any running system.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

