### PR TITLE
CASMHMS-5205 Reorder HMS CT smoke test execution csm-1.2

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -14,7 +14,7 @@ cray-orca=0.7.5-2.1_20210930095500__gac3cd47
 # HMS
 hms-bss-ct-test=1.11.0-1
 hms-capmc-ct-test=1.29.0-1
-hms-ct-test-base=1.9.0-1
+hms-ct-test-base=1.10.0-1
 hms-fas-ct-test=1.13.0-1
 hms-hmcollector-ct-test=2.14.0-1
 hms-hbtd-ct-test=1.13.0-1
@@ -24,7 +24,7 @@ hms-reds-ct-test=1.21.0-1
 hms-rts-ct-test=1.15.0-1
 hms-scsd-ct-test=1.8.0-1
 hms-sls-ct-test=1.11.0-1
-hms-smd-ct-test=1.32.0-1
+hms-smd-ct-test=1.36.0-1
 
 # SDU
 cray-sdu-rda=1.1.5-20210930134023_baa45ce


### PR DESCRIPTION
### Summary and Scope

This change updates the HMS CT smoke tests to execute the HSM tests first to more easily and clearly identify discovery-related problems.

### Issues and Related PRs

* Resolves CASMHMS-5205 in csm-1.2

### Testing

This change was tested by deploying the updated smoke tests and wrapper script to Wasp, executing them, and verifying that the HSM tests ran first. Failures of the HSM smoke tests were also verified to stop execution of the wrapper script as expected.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.