### PR TITLE
CASMPET-5173 Swap cray-nexus for new pit-nexus

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -1,6 +1,5 @@
 # CSM Packages
 apache2=2.4.43-3.25.1
-cray-nexus=0.9.1-3.1
 craycli=0.41.11
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.30

--- a/packages/cray-pre-install-toolkit/metal.packages
+++ b/packages/cray-pre-install-toolkit/metal.packages
@@ -8,3 +8,4 @@ metal-basecamp=1.1.9-1
 metal-ipxe=2.0.9-1
 metal-net-scripts=0.0.2-1
 pit-init=1.2.12-1
+pit-nexus=1.1.0-1.1


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

This swaps the old cray-nexus RPM for the new [pit-nexus RPM ](https://github.com/Cray-HPE/pit-nexus), this work is tagged with the recent bugfix for pit-nexus [CASMPET-5173](https://connect.us.cray.com/jira/browse/CASMPET-5173).

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5173](https://connect.us.cray.com/jira/browse/CASMPET-5173)
* Change will also be needed in `main`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `redbull`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Purging cray-nexus and installing pit-nexus resulted in a 🟢 good smoke-test of an NCN deployment; all NCNs deployed, k8s and ceph included. No CSM install was done.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

None.
