### PR TITLE
MTL-1574 print nexus info in metalid.sh

### DIFF
--- a/packages/cray-pre-install-toolkit/metal.packages
+++ b/packages/cray-pre-install-toolkit/metal.packages
@@ -7,4 +7,4 @@ kernel-syms=5.3.18-59.19.1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.0.9-1
 metal-net-scripts=0.0.2-1
-pit-init=1.2.11-1
+pit-init=1.2.12-1


### PR DESCRIPTION
This just additionally prints the nexus RPM info when `metalid.sh` is invoked.