### PR TITLE
CASMINST-3544 bios-baseline timeout

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.30
 
 # CSM Testing Utils
-goss-servers=1.8.34-1
+goss-servers=1.8.35-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Change timeout from 1000ms to 5000ms to wait longer for output to
return. In many cases output will emit before 1000ms, but it can take
slightly longer. 5000ms would cover most if not all cases.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-3544](https://connect.us.cray.com/jira/browse/CASMINST-3544)
* Change will also be needed in `main`
* Merge with https://github.com/Cray-HPE/csm-rpms/pull/139

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

If a system's networking is bogged or non-optimal, 5000ms might not be enough. However in those cases there would seem to be larger problems afoot, and this test should be disregarded until those larger problems are fixed.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

