### PR TITLE
Release CSI 1.12.2

### DIFF
--- a/packages/cray-pre-install-toolkit/metal.packages
+++ b/packages/cray-pre-install-toolkit/metal.packages
@@ -1,4 +1,4 @@
-cray-site-init=1.11.1-1
+cray-site-init=1.12.2-1
 ilorest=3.2.3-1
 kernel-default=5.3.18-59.19.1
 kernel-mft-mlnx-kmp-default=4.17.0_k5.3.18_57-1.sles15sp3


### PR DESCRIPTION
## Summary and Scope

Changes since 1.11.1:
* CASMINST-3029 - NCN Automation Business Logic
* MTL-1569 add backwards compatibility for handoff bss-metadata command
* CASMINST-3598 generate ipam metadata key and push into bss