### PR TITLE
Add DNSMASQ in since it no longer is Required by metal-ipxe and is no…

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -2,6 +2,7 @@
 apache2=2.4.43-3.25.1
 canu=0.0.6-1
 craycli=0.41.11
+dnsmasq=2.78-7.6.1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.29-1
 loftsman=1.1.0-20210511145236_2da0507

--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -1,11 +1,11 @@
 # CSM Packages
 apache2=2.4.43-3.25.1
+canu=0.0.6-1
 craycli=0.41.11
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.29-1
 loftsman=1.1.0-20210511145236_2da0507
 manifestgen=1.3.4-1~development~bbba190
-canu=0.0.6-1
 
 # SUSE Packages
 acl=2.2.52-4.3.1


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_


This change removed dnsmasq as a dependency to metal-ipxe, and since it is not explicitly installed by csm-rpms the package is now missing. This is a critical package necessary for the PIT, it provides DHCP, DNS, and netbooting capabilities.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes(?)

