### PR TITLE
CASMNET-1059: Bump CANU version to 1.0.0

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -1,6 +1,6 @@
 # CSM Packages
 apache2=2.4.43-3.25.1
-canu=0.0.6-1
+canu=1.0.0-1
 craycli=0.41.11
 dnsmasq=2.78-7.6.1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -1,6 +1,6 @@
 #CSM
 acpid=2.0.31-1.1
-canu=0.0.6-1
+canu=1.0.0-1
 cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
 craycli=0.41.8-1


### PR DESCRIPTION
## Summary and Scope

CANU has been updated to feature complete as of the 1.0.0 release and needs to be included in CSM 1.2 build.

## Issues and Related PRs


* Resolves CASMNET-1059
* Merge with`https://github.com/Cray-HPE/csm/pull/213`

### Tested on:

  * `wasp`
  * Local development environment


### Test description:

* Tested upgrade from 0.0.5 and 0.0.6 to 1.0.0.
* On system testing of SHCD validate, configuration generation and validation and cabling checks.

- Were continuous integration tests run? **YES**
- Was upgrade tested? **YES**
- Was downgrade tested? **NO** as downgrade to 0.0.6 or lower will not be useful on CSM 1.2 systems.

## Risks and Mitigations
None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

