### PR TITLE
CASMTRIAGE-2801 Add support for HPE PDUs to the HSM ComponentEndpoints CT test.

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -24,7 +24,7 @@ hms-reds-ct-test=1.21.0-1
 hms-rts-ct-test=1.15.0-1
 hms-scsd-ct-test=1.8.0-1
 hms-sls-ct-test=1.11.0-1
-hms-smd-ct-test=1.36.0-1
+hms-smd-ct-test=1.38.0-1
 
 # SDU
 cray-sdu-rda=1.1.5-20210930134023_baa45ce


### PR DESCRIPTION
### Summary and Scope

This change adds support for HPE PDUs to the HSM ComponentEndpoints CT test.

### Issues and Related PRs

* Resolves CASMTRIAGE-2801.

### Testing

This change was tested by deploying the updated HSM ComponentEndpoints CT test to the system Hela which has HPE PDUs, executing the test, and verifying that the previously failing test cases began to pass.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.