### PR TITLE
CRAYSAT-1241: Add `prodmgr` RPM to CSM k8s image

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -29,5 +29,8 @@ hms-smd-ct-test=1.38.0-1
 # SDU
 cray-sdu-rda=1.1.5-20210930134023_baa45ce
 
+# SAT
+cray-prodmgr-1.1.1-20211207144328_ba9d8c8
+
 # DVS
 insserv-compat=0.1-4.6.1

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -18,6 +18,8 @@ http://car.dev.cray.com/artifactory/ct-tests/HMS/sle15_sp2_ncn/x86_64/release/cs
 http://car.dev.cray.com/artifactory/sdu/SSA/sle15_sp2_ncn/noarch/release/sdu-1.1/                      cray-sdu-sle-15sp2-noarch-sdu-1.1                 --no-gpgcheck -p 89                   cray/sdu/sle-15sp2/noarch
 http://car.dev.cray.com/artifactory/sdu/SSA/sle15_sp2_ncn/x86_64/release/sdu-1.1/                      cray-sdu-sle-15sp2-x86_64-sdu-1.1                 --no-gpgcheck -p 89                   cray/sdu/sle-15sp2/x86_64
 
+https://arti.dev.cray.com/artifactory/sat-rpm-master-local/dev/master/sle15_sp2_ncn/                   cray-sat-sle-15sp2-x86_64-master                  --no-gpgcheck -p 89                   cray/sat/sle-15sp2/x86_64
+
 https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/hpe/                                        x86_64/canu                                       --no-gpgcheck -p 89                   cray/csm/sle-15sp3/x86_64
 https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/release/                                    cray-csm-rpm-stable-local-release                 --no-gpgcheck -p 89                   cray/csm/rpm/stable/local/release
 


### PR DESCRIPTION
## Summary and Scope

-Add SAT RPM repository to repos/cray.repos
- Add prodmgr RPM to Kubernetes node image by adding it to base.packages

## Issues and Related PRs

- Resolves [CRAYSAT-1241](https://connect.us.cray.com/jira/browse/CRAYSAT-1241)

## Testing

Tested locally by building a Kubernetes NCN image.

### Tested on:

- Local development environment

### Test description:

- Built a squashfs kubernetes image
- Mounted the resulting image and used chroot to check the RPM was installed and the command would run.

## Risks and Mitigations

N/A

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [N/A] Copyrights updated
- [N/A] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

