### PR TITLE
Fix Ops from GCP Reorg Yesterday

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -104,7 +104,6 @@ rsyslog=8.39.0-4.10.1
 rzsz=0.12.21~rc-1.8
 s3fs=1.83-3.3.1
 screen=4.6.2-5.3.1
-SLE_HPC-release=15.3-47.3.3
 smartmontools=7.0-6.1
 socat=1.7.3.2-4.10
 spire-agent=0.12.2-2_20210804172958_81fcb94

--- a/packages/node-image-non-compute-common/metal.packages
+++ b/packages/node-image-non-compute-common/metal.packages
@@ -10,3 +10,4 @@ kernel-mft-mlnx-kmp-default=4.17.0_k5.3.18_57-1.sles15sp3
 kernel-source=5.3.18-59.27.1
 kernel-syms=5.3.18-59.19.1
 ledmon=0.94-1.59
+SLE_HPC-release=15.3-47.3.3


### PR DESCRIPTION
#167 moved SLE HPC into base.packages by mistake, this needs to go back to metal.packages.