### PR TITLE
CASMTRIAGE-2823 main : TESTS: CSM validation metal.no-wipe check failing on storage nodes

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.30
 
 # CSM Testing Utils
-goss-servers=1.8.35-1
+goss-servers=1.8.37-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
CASMTRIAGE-2823: Add get_client_secret() function to check_no_wipe_flag.sh script
### Summary and Scope

The kubectl command is not available/functioning on all storage nodes. The
check_no_wipe_ flag.sh script needs to execute the kubectl command to obtain the
Client Secret.

Added get_client_secret() function to check_no_wipe_ flag.sh script. If executing on any
storage node, locates an active functioning Kubernetes NCN node (master or worker) where
to execute the kubectl command to obtain the Client Secret.

Tested on hela (1.2.0-alpha.31).

### Issues and Related PRs
CASMTRIAGE-2823

### Testing
Tested on hela, 1.2.0-alpha.31 installed.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A