### PR TITLE
CSI update for: CASMTRIAGE-2702, MTL-1568, CASMINST-3410, and CASMNET-1061

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -9,7 +9,7 @@ loftsman=1.1.0-20210511145236_2da0507
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.13.2-1
+cray-site-init=1.13.5-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.0.10-1


### PR DESCRIPTION
## Summary and Scope

* Fixes bug where empty CHN network was created in SLS when chn inputs are not provided to CSI
* Fixes bug where CHN interface was being added to ipam parameters in basecamp
* Handles cabinets-yaml with empty string
* Checks for csm-version input to make sure 1.0 inputs are not used in 1.2 installs

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMTRIAGE-2702
* Resolves MTL-1568
* Resolves CASMINST-3410
* Resolves CASMNET-1061

## Testing

### Tested on:

  * `drax`

### Test description:

Tested with various valid and invalid inputs to CSI on drax.  Checked the generated files to make sure they were correct.

## Risks and Mitigations

No known issues


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

