### PR TITLE
CASMINST-3596 metal-ipxe-2.0.11 requires dnsmasq

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -2,7 +2,6 @@
 apache2=2.4.43-3.25.1
 canu=1.0.0-1
 craycli=0.41.11
-dnsmasq=2.78-7.6.1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.30
 loftsman=1.1.0-20210511145236_2da0507
@@ -12,7 +11,7 @@ manifestgen=1.3.4-1~development~bbba190
 cray-site-init=1.13.5-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
-metal-ipxe=2.0.10-1
+metal-ipxe=2.0.11-1
 metal-net-scripts=0.0.2-1
 pit-init=1.2.12-1
 pit-nexus=1.1.0-1.1


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

The metal-ipxe RPM ceased requiring dnsmasq as a dependency in CASMINST-2120 as a "slim-down" enhancement. This change reverts that, and restores the notion that metal-ipxe requires dnsmasq before install (as a dependency).

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-3596](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3596)
* Change will also be needed in `main`
* Merge with 

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

No.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

