### PR TITLE
Casmuser 2812

### DIFF
--- a/packages/compute-node.packages
+++ b/packages/compute-node.packages
@@ -1,4 +1,4 @@
-craycli=0.41.11
+craycli=0.45.0
 cray-switchboard=1.2.3-1
 cray-uai-util=1.0.13-1
 cfs-state-reporter=1.7.50-1

--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -1,7 +1,7 @@
 # CSM Packages
 apache2=2.4.43-3.25.1
 canu=1.0.0-1
-craycli=0.41.11
+craycli=0.45.0
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.30
 loftsman=1.1.0-20210511145236_2da0507

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -3,7 +3,7 @@ acpid=2.0.31-1.1
 canu=1.0.0-1
 cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
-craycli=0.41.11
+craycli=0.45.0
 csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.30
 


### PR DESCRIPTION
## Summary and Scope

Move craycli RPM version to 0.45.0 to pick up the CSM 1.2 (NERSC Phase 2) UAS content.

This change is backward compatible

## Issues and Related PRs

* Resolves [CASMUSER-2812](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2812)

## Testing

### Tested on:

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

No known issues or risks

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ N/A ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ N/A ] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
