### PR TITLE
CASMINST-3701:  CSI - Fix empty string generated for hmn_api_gw

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -8,7 +8,7 @@ loftsman=1.1.0-20210511145236_2da0507
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.13.7-1
+cray-site-init=1.13.8-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.0.11-1


### PR DESCRIPTION
## Summary and Scope

The fix for CASMINST-2541 went a little too far when removing the api_gw_service aliases for HMN and removed the 10.94.100.71 reservation entirely. This reservation is still needed. This fix adds back that reservation but does it with no aliases.

See https://github.com/Cray-HPE/cray-site-init/pull/110 for more information.

## Issues and Related PRs

* Resolves CASMINST-3701

## Testing

### Test description:

This was tested on my laptop by building CSI locally and running csi config init on Hela's seed files. I did a comparison against what was generated with the main branch.

## Risks and Mitigations

No known issues


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

