### PR TITLE
CASMTRIAGE-2836: update index to pull in v1.8.40 released version of …

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.30
 
 # CSM Testing Utils
-goss-servers=1.8.37-1
+goss-servers=1.8.40-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
### Summary and Scope
CASMTRIAGE-2836: Fix etcd_backups_check.sh script

Update to packages file to pull in v1.8.40 released version of goss-servers
This pulls in changes for:
* CASMTRIAGE-2836

When the etcd_backups_check.sh' script was executed within goss, an incorrect date string was being returned. 
In the etcd_backups_check.sh's script check_backup_within_day() function, replaced ${backup: -20}
with ${backup##*_} to always return the correct sub-string. Fixed problem.

Tested on hela (1.2.0-alpha.31).

### Issues and Related PRs
CASMTRIAGE-2836

### Testing
Tested on hela, 1.2.0-alpha.31 installed.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A
