### PR TITLE
CRAYSAT-1246: update prodmgr rpm

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -30,7 +30,7 @@ hms-smd-ct-test=1.38.0-1
 cray-sdu-rda=1.1.5-20210930134023_baa45ce
 
 # SAT
-cray-prodmgr-1.1.1-20211207144328_ba9d8c8
+cray-prodmgr-1.1.2-20220104153307_2374f1f
 
 # DVS
 insserv-compat=0.1-4.6.1


### PR DESCRIPTION
## Summary and Scope

This updates the version of the `prodmgr` RPM to a newer version that includes a man page.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

* Resolves CRAYSAT-1246

## Testing

### Tested on:

  * `lemondrop`
  * Local development environment

### Test description:

  * I built the image locally using `packer`
  * I installed the RPM on lemondrop and ran the command.

## Risks and Mitigations

N/A

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [N/A] Copyrights updated
- [N/A] License file intact
- [Y] Target branch correct
- [N/A] CHANGELOG.md updated
- [Y] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable