### PR TITLE
CASMPET-4660 1.2 : Automate check for Postgres pod backups

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.30
 
 # CSM Testing Utils
-goss-servers=1.8.40-1
+goss-servers=1.8.42-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
Added goss test and script to automate check for postgres pod backups (work done by Lindsay)

## Summary and Scope

This is a new automation feature. It is a goss test that ensures that recent PostgreSQL pod backups exist for specific clusters.

Change a new feature, it is backwards compatible.

## Issues and Related PRs

* Part of the 'Automation: Validate CSM Health (PET)' epic. CASM-2592
* CASMPET-4660 : Automate check for Postgres pod backups
* CASMPET-5145 : Add multiple tries to goss-k8s-postgres-replication-lag (this was merged to master a few weeks back and was just noted as missing from 1.2)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * wasp
  * Hela
 
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

This is a read only script that will report PASS or FAIL status.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable