### PR TITLE
MTL-1598 Remove hexane until actually desired, if at all

### DIFF
--- a/packages/cray-pre-install-toolkit/metal.packages
+++ b/packages/cray-pre-install-toolkit/metal.packages
@@ -7,7 +7,6 @@ kernel-source=5.3.18-59.19.1
 kernel-syms=5.3.18-59.19.1
 ledmon=0.94-1.59
 SLE_HPC-release=15.3-47.3.3
-hexane=1.0.7-1
 hpe-mlnx-ofed-default=5.4_1.0.3.0_5.3.18_57_default-1.sles15sp3
 mft=4.17.0-106
 mlnx-ethtool=5.10-1.54103

--- a/packages/node-image-non-compute-common/metal.packages
+++ b/packages/node-image-non-compute-common/metal.packages
@@ -10,7 +10,6 @@ kernel-source=5.3.18-59.27.1
 kernel-syms=5.3.18-59.19.1
 ledmon=0.94-1.59
 SLE_HPC-release=15.3-47.3.3
-hexane=1.0.7-1
 hpe-mlnx-ofed-default=5.4_1.0.3.0_5.3.18_57_default-1.sles15sp3
 mft=4.17.0-106
 mlnx-ethtool=5.10-1.54103


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Hexane should be yanked out of 1.2, it was brought in recently as a curiosity but it could enable nefarious/wrong-doings on a system. The nature of the program pertains to TPM/SecureBoot, and can prevent a server from booting when used incorrectly.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

