### PR TITLE
CASMHMS-5312 Update hms-pytest image location for Nexus main

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -14,7 +14,7 @@ cray-orca=0.7.5-2.1_20210930095500__gac3cd47
 # HMS
 hms-bss-ct-test=1.11.0-1
 hms-capmc-ct-test=1.29.0-1
-hms-ct-test-base=1.10.0-1
+hms-ct-test-base=1.11.0-1
 hms-fas-ct-test=1.13.0-1
 hms-hmcollector-ct-test=2.14.0-1
 hms-hbtd-ct-test=1.13.0-1


### PR DESCRIPTION
### Summary and Scope

This change updates the path to the hms-pytest image in Nexus since images are no longer being uploaded to the old location.

### Issues and Related PRs

* Resolves CASMHMS-5312.

### Testing

This change was tested on Mug running csm-1.2.0-alpha.43 by pulling the hms-pytest image from the new location and verifying that the previously failing CT tests began to pass. Also verified with Zach C. that the new path is correct and that the previous location is no longer supported.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk that fixes an out-of-date image path.