### PR TITLE
New version of goss-servers

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.30
 
 # CSM Testing Utils
-goss-servers=1.8.43-1
+goss-servers=1.8.45-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
## Summary and Scope

Allow the livecd bios baseline test more time to run the underlying script (timing out with 5 seconds).

## Issues and Related PRs

* Resolves [CASMINST-3696](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3696)

## Testing

Ran on surtur

### Tested on:

  * `surtur`

### Test description:

Ran on surtur -- got past the timeout.  I couldn't figure out how to set the ipmi creds properly, but that's probably me.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable