### PR TITLE
CASMHMS-5310 Remove duplicate CabinetPDUController output from verify_hsm_discovery csm-1.2

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -3,7 +3,7 @@ apache2=2.4.43-3.25.1
 canu=1.1.1-1
 craycli=0.45.0
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
-hpe-csm-scripts=0.0.30
+hpe-csm-scripts=0.0.31
 loftsman=1.1.0-20210511145236_2da0507
 manifestgen=1.3.4-1~development~bbba190
 

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -5,7 +5,7 @@ cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
 craycli=0.45.0
 csm-node-identity=1.0.18-1
-hpe-csm-scripts=0.0.30
+hpe-csm-scripts=0.0.31
 
 # CSM Testing Utils
 goss-servers=1.8.45-1


### PR DESCRIPTION
### Summary and Scope

This change removes a duplicated code block from verify_hsm_discovery.py which stops it from running and printing the checks for CabinetPDUControllers twice instead of once. The extra output was causing confusion during installs while troubleshooting discovery failures.

### Issues and Related PRs

* Resolves CASMHMS-5310.

### Testing

This change was tested on Mug running csm-1.2.0-alpha.43 by copying the new version of the script onto the NCN, running it, and verifying that the duplicated output from the original script was no longer present in the updated version.

Previous (two identical "CabinetPDUControllers" entries per cabinet):

```
<snip>
River Cabinet Checks
====================
x3000
  Nodes: PASS
  NodeBMCs: WARNING
    - x3000c0s1b0 - Not found in HSM Components; No mgmt port connection; BMC of mgmt node ncn-m001.
  RouterBMCs: FAIL
    - x3000c0r24b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
  CabinetPDUControllers: PASS
  ChassisBMCs/CMCs: FAIL
    - x3000c0s19b999 - Not found in HSM Components; Not found in HSM Redfish Endpoints; No mgmt port connection.
  CabinetPDUControllers: PASS
x3001
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS
  CabinetPDUControllers: PASS
  ChassisBMCs/CMCs: PASS
  CabinetPDUControllers: PASS
<snip>
```

New (one "CabinetPDUControllers" entry per cabinet):

```
<snip>
River Cabinet Checks
====================
x3000
  Nodes: PASS
  NodeBMCs: WARNING
    - x3000c0s1b0 - Not found in HSM Components; No mgmt port connection; BMC of mgmt node ncn-m001.
  RouterBMCs: FAIL
    - x3000c0r24b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
  ChassisBMCs/CMCs: FAIL
    - x3000c0s19b999 - Not found in HSM Components; Not found in HSM Redfish Endpoints; No mgmt port connection.
  CabinetPDUControllers: PASS
x3001
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS
  ChassisBMCs/CMCs: PASS
  CabinetPDUControllers: PASS
<snip>
```

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.