### PR TITLE
1.2 casminst-3485

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -1,6 +1,6 @@
 # CSM Packages
 apache2=2.4.43-3.25.1
-canu=1.1.1-1
+canu=1.1.3-1
 craycli=0.45.0
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.31

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -1,6 +1,6 @@
 #CSM
 acpid=2.0.31-1.1
-canu=1.1.1-1
+canu=1.1.3-1
 cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
 craycli=0.45.0


### PR DESCRIPTION
## Summary and Scope

Canu version bump
- Adds canu testing feature
- Fixed canu validate BGP for csm 1.2

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

CASMINST-3485

## Testing


### Tested on:

Drax, Hela, vritualEnv

### Test description:

successfully ran CANU on the systems above.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

