### PR TITLE
CASMINST-3866 - Check target directory exists before attempting to copy image artifacts

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -8,7 +8,7 @@ loftsman=1.1.0-20210511145236_2da0507
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.14.3-1
+cray-site-init=1.14.4-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.1.0-1


### PR DESCRIPTION
## Summary and Scope

When copying the node images csi does not verify the existence of the target directory resulting in a somewhat confusing error message should it not exist.

## Issues and Related PRs

* Resolves [CASMINST-3866](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3866)

## Testing

### Tested on:

  * `hela`
  * Local development environment

### Test description:

Old behaviour
```
ncn-m001:~ # csi pit populate pitdata "${CSM_RELEASE}/images/kubernetes/" /mnt/pitdata/data/k8s/ -kiK
5.3.18-59.34-default-0.2.43.kernel----------------> /mnt/pitdata/data/k8s/...Failed "open /mnt/pitdata/data/k8s/5.3.18-59.34-default-0.2.43.kernel: no such file or directory"
initrd.img-0.2.43.xz------------------------------> /mnt/pitdata/data/k8s/...Failed "open /mnt/pitdata/data/k8s/initrd.img-0.2.43.xz: no such file or directory"
kubernetes-0.2.43.squashfs------------------------> /mnt/pitdata/data/k8s/...Failed "open /mnt/pitdata/data/k8s/kubernetes-0.2.43.squashfs: no such file or directory"
```

New behaviour
```
ncn-m001:~ # csi pit populate pitdata "${CSM_RELEASE}/images/kubernetes/" /mnt/pitdata/data/k8s/ -kiK
2022/01/27 10:47:16 Error: target directory /mnt/pitdata/data/k8s/ does not exist
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

