### PR TITLE
(CSM 1.2) CASMINST-3831 bump CSI version

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -8,7 +8,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.14.5-1
+cray-site-init=1.14.6-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.1.1-1


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Regenerate the the BSS host_records metadata using data from SLS during CSM 1.2 upgrade

https://github.com/Cray-HPE/cray-site-init/pull/117

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-3831

## Testing

_List the environments in which these changes were tested._
For Testing see: https://github.com/Cray-HPE/cray-site-init/pull/117

## Risks and Mitigations
Requires additional end to end testing on Baremetal during a CSM 1.2 upgrade. But all of the changes made to a system are contained within the Global boot parameters in BSS, which currently contains incorrect host record data after a CSM 1.2 upgrade.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable