### PR TITLE
CASMCMS-7783 Manifest Update

### DIFF
--- a/packages/compute-node.packages
+++ b/packages/compute-node.packages
@@ -2,4 +2,4 @@ craycli=0.45.0
 cray-switchboard=1.2.3-1
 cray-uai-util=1.0.13-1
 cfs-state-reporter=1.7.50-1
-cfs-trust=1.3.94-1
+cfs-trust=1.4.4-1

--- a/packages/extra.packages
+++ b/packages/extra.packages
@@ -1,5 +1,5 @@
 cf-ca-cert-config-framework=2.3.5-1
-cfs-trust=1.3.94-1
+cfs-trust=1.4.4-1
 csm-ssh-keys=1.3.79-1
 csm-ssh-keys-roles=1.3.79-1
 shasta-authorization-module=1.6.2-1

--- a/packages/node-image-non-compute-common/cms.packages
+++ b/packages/node-image-non-compute-common/cms.packages
@@ -1,3 +1,3 @@
 #CMS
 cfs-state-reporter=1.7.50-1
-cfs-trust=1.3.94-1
+cfs-trust=1.4.4-1


### PR DESCRIPTION
## Summary and Scope

This mod changes the population behavior for cfs-trust; this migrates
the behavior over to a patch operation in order to be a good citizen for
any service that ends up populating information afterwards. Normally, we
don't re-PUT once our key is there, and since our services is one of the
first to push content into the bss metadata service, there is no
problem.

However, during an upgrade or scenarios where cfs-trust metadata goes
missing, subsequent PUT operations zero any incidental keys stored in
BSS metadata global section; this information then needs to be recovered
(sometimes manually).

Finally, this mod updates the behavior of cfs-trust and changes it to
re-populate our missing key if it ever goes missing for whatever reason.
Previously, a pod restart would accomplish this similar behavior but now
that is no longer needed. The existing resigning/republishing loop is
used to accomplish this, so BSS metadata healing happens every 6 hours
or so.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-7783](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7783)

## Testing

Replaced functionality was exercised within the cfs-trust pod on wasp; all bss-metadata was backed up prior to testing to ensure the PATCH function matched the lossless behavior desired.

### Tested on:
  * wasp


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable