### PR TITLE
Update package version for hpe-csm-scripts

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -3,7 +3,7 @@ apache2=2.4.43-3.25.1
 canu=1.1.4-1
 craycli=0.46.0
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
-hpe-csm-scripts=0.0.31
+hpe-csm-scripts=0.0.32
 loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -5,7 +5,7 @@ cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
 craycli=0.46.0
 csm-node-identity=1.0.18-1
-hpe-csm-scripts=0.0.31
+hpe-csm-scripts=0.0.32
 
 # CSM Testing Utils
 goss-servers=1.10.4-1


### PR DESCRIPTION
## Summary and Scope

Update package version for hpe-csm-scripts for CASMHMS-5346 - Change lock_management_nodes.py to lock nodeBMCs of management nodes

## Issues and Related PRs

* Resolves [CASMHMS-5346](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5346)

## Testing

For testing, see https://github.com/Cray-HPE/hpe-csm-scripts/pull/9

## Risks and Mitigations

low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

