### PR TITLE
CASMHMS-5365 Update HSM CT tests for custom component roles and subroles.

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -24,7 +24,7 @@ hms-reds-ct-test=1.21.0-1
 hms-rts-ct-test=1.15.0-1
 hms-scsd-ct-test=1.8.0-1
 hms-sls-ct-test=1.11.0-1
-hms-smd-ct-test=1.38.0-1
+hms-smd-ct-test=1.45.0-1
 
 # SDU
 cray-sdu-rda=1.1.5-20210930134023_baa45ce


### PR DESCRIPTION
### Summary and Scope

This change updates the HSM CT tests to allow custom component roles and subroles. Previously these were expected to be one of the pre-defined roles but now we've added support and documentation for setting custom roles. Sites using custom roles or subroles (as seen on Pawsey, for example) will encounter HMS validation test failures without this update.

### Issues and Related PRs

* Resolves [CASMHMS-5365](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5365).

### Testing

This change was tested on Mug by deploying the updated tests, executing them after setting a custom node SubRole in HSM, and verifying that the previously failing test cases began to pass.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Very low risk, great benefit to stop false test failures from being reported.