### PR TITLE
MTL-1604: CVE-2021-4034: pwnkit: Local Privilege Escalation in polkit's pkexec [release/1.0]

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -71,3 +71,7 @@ wget=1.20.3-3.12.1
 which=2.21-2.20
 wireshark=3.4.5-3.53.1
 wol=0.7.1-2.5
+
+# Polkit packages with fix for CVE-2021-4034 are available from LTSS repo
+polkit=0.116-3.6.1
+libpolkit0=0.116-3.6.1

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -127,3 +127,7 @@ wget=1.20.3-3.12.1
 wireshark=3.4.5-3.53.1
 xfsdump=3.1.6-1.30
 zip=3.0-2.22
+
+# Polkit packages with fix for CVE-2021-4034 are available from LTSS repo
+polkit=0.116-3.6.1
+libpolkit0=0.116-3.6.1


### PR DESCRIPTION
## Summary and Scope

Update polkit packages on PIT and NCN nodes to version `0.116-3.6.1`. This version is available for SLES 15 SP2 distros through LTSS repos (original SLES 15 SP2 ISO comes with `0.116-3.3.1`). According to https://www.suse.com/de-de/security/cve/CVE-2021-4034.html, this version contains a fix for CVE-2021-4034.

## Issues and Related PRs

* Resolves [MTL-1604](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1604)

## Testing

Ran image builds to verify:
https://jenkins.algol60.net/job/Cray-HPE/job/cray-pre-install-toolkit/job/release%252Fcsm-1.0/6/consoleFull

    [ DEBUG   ]: 21:18:44 | (217/227) Installing: libpolkit0-0.116-3.6.1.x86_64 [........done]
    [ DEBUG   ]: 21:19:13 | (218/227) Installing: kernel-source-5.3.18-24.99.1.noarch [..................done]
    [ DEBUG   ]: 21:19:14 | (219/227) Installing: kernel-preempt-devel-5.3.18-24.99.1.x86_64 [............done]
    [ DEBUG   ]: 21:19:16 | (220/227) Installing: kernel-default-devel-5.3.18-24.99.1.x86_64 [............done]
    [ DEBUG   ]: 21:19:16 | (221/227) Installing: polkit-0.116-3.6.1.x86_64 [..........done]

https://jenkins.algol60.net/job/Cray-HPE/job/node-image-build/job/lts%2Fcsm-1.0/31/consoleFull

    00:49:30.062      qemu.ncn-common: (348/544) Installing: libpolkit0-0.116-3.6.1.x86_64 [............done]
    00:50:08.752      qemu.ncn-common: (353/544) Installing: polkit-0.116-3.6.1.x86_64 [..................done]
    00:50:13.376      googlecompute.ncn-common: (350/539) Installing: polkit-0.116-3.6.1.x86_64 [..................done]
    00:49:41.322      googlecompute.ncn-common: (345/539) Installing: libpolkit0-0.116-3.6.1.x86_64 [............done]