### PR TITLE
Allow errors in rpm scriptlets

### DIFF
--- a/scripts/rpm-functions.sh
+++ b/scripts/rpm-functions.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 CSM_RPMS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")/.." &> /dev/null && pwd )"
 

--- a/scripts/rpm-functions.sh
+++ b/scripts/rpm-functions.sh
@@ -92,12 +92,15 @@ function list-compute-packages() {
 }
 
 function install-packages() {
+  # rpm scripts often exit with errors, which should not break any scripts calling us
+  set +e
   if [[ "$DEV" = 'true' ]]; then
     echo >&2 "DEV: $DEV"
     remove-comments-and-empty-lines "$1" | xargs -t -r zypper -n install --oldpackage --auto-agree-with-licenses --no-recommends --allow-unsigned-rpm
   else
     remove-comments-and-empty-lines "$1" | xargs -t -r zypper -n install --oldpackage --auto-agree-with-licenses --no-recommends
   fi
+  set -e
 }
 
 function update-package-versions() {


### PR DESCRIPTION
## Summary and Scope

Ensure `set +e` is set for rpm installs.  Some callers of this function execute in an environment where certain commands or capabilities may not be present.  For example, the LiveCD build, which uses these csm-rpms functions from within a script that has `set -e`.  It is common for rpm scripts to encounter errors.  These should not halt the execution of the calling script.