### PR TITLE
CASMINST-4001: Update goss-server package to 1.11.0

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.32
 
 # CSM Testing Utils
-goss-servers=1.10.5-1
+goss-servers=1.11.0-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
## Summary and Scope

This adds tests that are run on workers and storage nodes after the nodes have been deployed in fresh install (csi pit validate --ceph and csi pit validate --k8s) and after they are upgraded.

## Issues and Related PRs

* Resolves CASMINST-4001
* Related to CASMINST-3828

## Testing


### Tested on:

  * `fanta`

### Test description:

Ran `csi pit validate --ceph` and `csi pit validate --k8s` to test fresh install
Ran `ncn-upgrade-tests-storage.yaml` and `ncn-upgrade-tests-storage.yaml` to test upgrades.

Verified that the new test shows up in the output and passes.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

