### PR TITLE
Add k8s python module to storage nodes for bican route script

### DIFF
--- a/packages/node-image-storage-ceph/base.packages
+++ b/packages/node-image-storage-ceph/base.packages
@@ -1,5 +1,6 @@
 # Base
 python3-boto3=1.17.9-19.1
+python3-kubernetes=8.0.1-3.5.1
 python3-six=1.14.0-10.1
 python3-netaddr=0.7.19-1.17
 netcat-openbsd=1.178-1.24


### PR DESCRIPTION
## Summary and Scope

Add kubernetes python module to storage nodes so bican scripting can talk to sls for bican toggle and network configs.

## Issues and Related PRs

* Resolves [CASMNET-1154](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1154)

## Testing

A bit on wasp -- looks like that's the only missing module, but installing the rpm directly w/out all the repos pulls in too many dependencies.

### Tested on:

  * `wasp`

### Test description:

Stopped short of installing the whole dependency chain

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
