### PR TITLE
Add bican-utils rpm to common image

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -1,5 +1,6 @@
 #CSM
 acpid=2.0.31-1.1
+bican-utils=0.0.1-1
 canu=1.1.4-1
 cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145


### PR DESCRIPTION
## Summary and Scope

Minor refactoring of the scripts and directory structure, package and publish rpm for install on ncns, callable from CFS play.

## Issues and Related PRs

* Resolves [CASMNET-818](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-818)

## Testing

```
bi-can-default-route.py   bi-can-get-sls-toggle.py  bi-can-interface.py       bi-can-ssh.py
ncn-w004:~ # /opt/cray/bican-utils/bi-can-default-route.py CHN
CHN Default Gateway 10.103.0.193
The current default gateway is 10.103.0.1
INTERFACE STATUS
['hsn0', 'hsn1']
('INTERFACE: hsn0 STATE: up CARRIER: up IP: 10.253.0.1', '10.253.0.1')
('INTERFACE: hsn1 STATE: up CARRIER: up IP: 10.253.0.20', '10.253.0.20')

ping test to 10.103.0.193 passed
changing the default route to 10.103.0.193
/etc/sysconfig/network/ifroute-hsn0 already exists and file contents are correct
/etc/sysconfig/network/ifroute-hsn1 already exists and file contents are correct
```
```
ncn-w004:~ # /opt/cray/bican-utils/bi-can-default-route.py CMN
CMN Default Gateway 10.103.0.1
The current default gateway is 10.103.0.193
INTERFACE STATUS
['bond0.cmn0']
('INTERFACE: bond0.cmn0 STATE: up CARRIER: up IP: 10.103.0.22', '10.103.0.22')

ping test to 10.103.0.1 passed
changing the default route to 10.103.0.1
/etc/sysconfig/network/ifroute-bond0.cmn0 already exists and file contents are correct
```

```
ncn-w004:~ # /opt/cray/bican-utils/bi-can-interface.py CHN
hostname: ncn-w004
CHN IP from SLS: None
CHN_Network from SLS: 10.103.0.192/26
CHN_VLAN from SLS: 5
/etc/sysconfig/network/ifcfg-hsn0 exists
CHN interface already configured
('INTERFACE: hsn0 STATE: up CARRIER: up IP: 10.253.0.1', '10.253.0.1')
Ping test to 10.103.0.193 from the CHN interface is successful
```

```
ncn-w004:~ # /opt/cray/bican-utils/bi-can-interface.py CMN
hostname: ncn-w004
CMN IP from SLS: 10.103.0.22
CMN_Network from SLS: 10.103.0.0/25
CMN_VLAN from SLS: 7
/etc/sysconfig/network/ifcfg-bond0.cmn0 exists
CMN interface already configured
('INTERFACE: bond0.cmn0 STATE: up CARRIER: up IP: 10.103.0.22', '10.103.0.22')
Ping test to 10.103.0.1 from the CMN interface is successful
```
```
ncn-w004:~ # /opt/cray/bican-utils/bi-can-ssh.py CHN
CHN interface configured
fe80::1602:ecff:feda:bcf8
INTERFACE: bond0.chn0 STATE: up CARRIER: up IP: fe80::1602:ecff:feda:bcf8
/etc/ssh/sshd_config is missing the correct configuration, adding it now
"ListenAddress fe80::1602:ecff:feda:bcf8" appended to /etc/ssh/sshd_config
```

```
ncn-w004:~ # /opt/cray/bican-utils/bi-can-ssh.py CMN
CMN interface configured
10.103.0.22
INTERFACE: bond0.cmn0 STATE: up CARRIER: up IP: 10.103.0.22
/etc/ssh/sshd_config is missing the correct configuration, adding it now
"ListenAddress 10.103.0.22" appended to /etc/ssh/sshd_config
```

```
ncn-w004:~ # /opt/cray/bican-utils/bi-can-get-sls-toggle.py
CMN
```

### Tested on:

  * `hela`

### Test description:

Installed rpm on ncn-w004/hela and ran each script with CHN/CMN arg

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

