### PR TITLE
Change velero backup test remediation to really delete PartiallyFailed backups

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.32
 
 # CSM Testing Utils
-goss-servers=1.12.1-1
+goss-servers=1.12.4-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
## Summary and Scope

Remediation steps for velero backup test don't permanently delete a backup, need to use velero command instead (not kubectl).

## Issues and Related PRs

* Resolves [CASMINST-4059](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4059)

## Testing

Ran the velero delete on surtur, the backup did not come back.

### Tested on:

  * `surtur`

### Test description:

Manually ran the new remediation step and it worked.

## Risks and Mitigations

None/Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable