### PR TITLE
CASMINST-4069 Update HSM components test for new expected BMC management roles csm-1.2

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -24,7 +24,7 @@ hms-reds-ct-test=1.21.0-1
 hms-rts-ct-test=1.15.0-1
 hms-scsd-ct-test=1.8.0-1
 hms-sls-ct-test=1.11.0-1
-hms-smd-ct-test=1.45.0-1
+hms-smd-ct-test=1.48.0-1
 
 # SDU
 cray-sdu-rda-1.2.1-shasta_20220202150011_8417c4c


### PR DESCRIPTION
### Summary and Scope

This change updates the HSM /State/Components tests for the new expected Management roles of BMCs. A recent change was made for [CASMHMS-5346](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5346) to set the Management role in HSM for BMCs of NCNs for the purposes of locking. The test was not updated in accordance with that change, so adding the new expected roles to the test schema now.

### Issues and Related PRs

* Resolves CASMINST-4069.

### Testing

This change was tested on Surtur by deploying the updated version of the test, executing it with Management BMC roles set in HSM, and verifying that the previously failing test cases began to pass.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, fixes a problem that will cause HMS test failures.