### PR TITLE
CASMNET-1157: Add edge switches to MetalLB config for CHN

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -8,7 +8,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.14.9-1
+cray-site-init=1.16.0-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.1.2-1


### PR DESCRIPTION
## Summary and Scope

This adds the capability to specify edge routers in switch_metadata.csv to get them added to SLS with xnames and get them added as CHN peers to the metallb config map.

See https://github.com/Cray-HPE/cray-site-init/pull/121

## Issues and Related PRs

* Resolves CASMNET-1157

## Testing

#### Testing

I have tested this by running `csi config init` with hela seed files using various combinations of inputs.

* With two edge switches specified and bgp-peer-types set to [spine, edge]
* Without edge switches specified in switch_metadata.csv
* With two edge switches specified but bgp-peer-types set to [spine]
* With no edge switches specified but bgp-peer-types set to [spine, edge]
* With only one edge switch specified
* With and without CHN defined in CSI inputs



## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable


