### PR TITLE
Use previous version only

### DIFF
--- a/repos/hpe.template.repos
+++ b/repos/hpe.template.repos
@@ -1,4 +1,4 @@
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/hpe-mirror-mlnx_ofed_cx4plus/SLES15-SP3/x86_64/current?auth=basic     hpe-mirror-mlnx_ofed_cx4plus --no-gpgcheck -p 90    SLES15-SP3/x86_64/current
+#https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/hpe-mirror-mlnx_ofed_cx4plus/SLES15-SP3/x86_64/current?auth=basic     hpe-mirror-mlnx_ofed_cx4plus --no-gpgcheck -p 90    SLES15-SP3/x86_64/current
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/hpe-mirror-mlnx_ofed_cx4plus/SLES15-SP3/x86_64/5.4-1.0.3.0?auth=basic     hpe-mirror-mlnx_ofed_cx4plus-5.4-1.0.3.0 --no-gpgcheck -p 90    SLES15-SP3/x86_64/current
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/hpe-mirror-hexane/15/x86_64/current?auth=basic                        hpe-mirror-hexane            --no-gpgcheck -p 90    15/x86_64/current
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/hpe-mirror-spp/SLES15/x86_64/current?auth=basic                       hpe-mirror-spp               --no-gpgcheck -p 99    SLES15/x86_64/current


### PR DESCRIPTION
## Summary and Scope

This will need to be revised once the upstream repodata for `current` is repaired.  See also the previous merge to this branch.