### PR TITLE
CASMINST-4089-CASMINST-1173:  Update cray-site-init RPM to 1.16.1

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -8,7 +8,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.16.0-1
+cray-site-init=1.16.1-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.1.2-1


### PR DESCRIPTION
## Summary and Scope

This set of changes fixes both CASMINST-4089 and CASMNET-1173

CASMINST-4089 - A valid configuration can have either CAN, CHN, or both. This fixes the case where setting the host records with either CAN or CHN are not specified caused a failure. I also added unit tests for the use cases of: only CAN is defined, only CHN is defined, neither CAN nor CHN are defined. The last case is expected to cause a failure and the unit test checks for that.

CASMNET-1173 - The prefix-length for CAN and CMN interaces in the ipam settings of BSS should come from the CAN/CMN supernet and not from the bootstrap subnet. This fixes those settings. It also fixed the unit tests to ensure that they are set appropriately. This was not caught previously in unit tests because the SLS test data was not as it would be normally (i.e. the bootstrap subnets did not have the same prefix-length that we would see from the SLS updater).

## Testing

### Tested on:

  * `fanta`

### Test description:

The CASMINST-4089 fix was installed on fanta and run to unblock Di on this issue. He verified that he was no longer hitting the failure in csi upgrade metadata when CHN was not defined.

I also ran the unit tests and verified that they failed without the fixes and passed with the fixes.

While running the unit tests, I found that the shcd_test was failing (without anything that was changed in these fixes) so I fixed that tests as well.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

