### PR TITLE
CASMINST-4116: Update cray-site-init RPM to 1.16.2

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -8,7 +8,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.16.1-1
+cray-site-init=1.16.2-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.1.2-1


### PR DESCRIPTION
#### Summary and Scope

- Fixes #CASMINST-4116


##### Issue Type
- Bugfix Pull Request

The HPE master and storage nodes have two NICs with two ports each.  In 1.0, these devices were named mgmt0, mgmt1, mgmt2, and mgmt3 and we would specify on the kernel cmdline which of those two devices made up bond0.  In 1.2, the device naming has changes to mgmt0, mgmt1, sun0, and sun1 and we presume that bond0 is always mgmt0 and mgmt1.   However the device that is named mgmt1 is different in 1.2 than it was in 1.0.   Because of all of this we need to make sure that `csi upgrade metadata` changes the ifnames to be what is expected for 1.2.    Master and storage nodes with only 1 NIC (on GB and Intel) can be left as they are.

I added several unit tests to check both 1 NIC and 2 NIC cases for Master and Storage as well as for the Worker nodes.  I also added tests for the rest of items that we change in the kernel parameters.

This change required and additional parameter be added to the updateParams function to be able to add multiple parameters with the same key (i.e. ifname).

#### Prerequisites

- [N/A] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (surtur) 

I ran all of the unit tests successfully and verified that the resulting kernel parameters are as expected for all cases.
I also installed a test csi rpm on surtur and ran `csi handoff bss-update-param` to make sure that the change to the updateParams function did not break that command.