### PR TITLE
Update csm-testing/goss-servers to v1.6.51

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -21,7 +21,7 @@ mdadm=4.1-15.32.1
 canu=0.0.5~alpha~2~master.852bef9-1
 
 # CSM Testing Utils
-goss-servers=1.6.50-1
+goss-servers=1.6.51-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
Pull in:
* Move interface MAC check into script file
* CASMINST-4157: Increase some test timeouts to avoid false failures
* Appease the license checker
* Remove needless comment from livecd preflight script
* Replace hard-coded paths with GOSS_BASE variable; protect string variables with quotes
* Make script hash-bang lines consistent
* Correct grep command regular expressions
* CASMINST-4157: Remove unnecessary -it arguments to kubectl exec commands in scripts