### PR TITLE
Update csm-testing/goss-servers to v1.12.15

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.32
 
 # CSM Testing Utils
-goss-servers=1.12.14-1
+goss-servers=1.12.15-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
Pull in:
* CASMINST-4223: Enable logging for bmc-check, podman-basecamp, podmap-nexus
* CASMINST-4224: Move tests to scripts and enable logging for bond-members-have-correct-mtu, switch-bgp-neighbor-aruba-or-mellanox