### PR TITLE
CASMHMS-4974 Add support for HSM /v2/locks/status 'GET' operation for listing all locks

### DIFF
--- a/packages/compute-node.packages
+++ b/packages/compute-node.packages
@@ -1,4 +1,4 @@
-craycli=0.48.0
+craycli=0.50.0-1
 cray-switchboard=1.2.3-1
 cray-uai-util=1.0.13-1
 cfs-state-reporter=1.7.50-1

--- a/packages/compute-node.packages
+++ b/packages/compute-node.packages
@@ -1,4 +1,4 @@
-craycli=0.46.0
+craycli=0.48.0
 cray-switchboard=1.2.3-1
 cray-uai-util=1.0.13-1
 cfs-state-reporter=1.7.50-1

--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -1,7 +1,7 @@
 # CSM Packages
 apache2=2.4.43-3.25.1
 canu=1.5.7-1
-craycli=0.46.0
+craycli=0.48.0
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.32
 loftsman=1.2.0-1

--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -1,7 +1,7 @@
 # CSM Packages
 apache2=2.4.43-3.25.1
 canu=1.5.7-1
-craycli=0.48.0
+craycli=0.50.0-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.32
 loftsman=1.2.0-1

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -4,7 +4,7 @@ canu=1.5.7-1
 cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
 cray-kubectl-hns-plugin=1.0.0-1
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
-craycli=0.46.0
+craycli=0.48.0
 csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.32
 

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -4,7 +4,7 @@ canu=1.5.7-1
 cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
 cray-kubectl-hns-plugin=1.0.0-1
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
-craycli=0.48.0
+craycli=0.50.0-1
 csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.32
 


### PR DESCRIPTION
### Summary and Scope

This change adds support for the 'GET' operation to the HSM /v2/locks/status API which will list the lock status of all components in HSM. Optional query parameters may be supplied to filter the results based on component Type, State, Role, SubRole, and Locked, Reserved, ReservationDisabled status. Several corrections to the HSM Swagger specification and a few minor CT test updates are also included.

### Issues and Related PRs

* Resolves CASMHMS-4974.

### Testing

This change was tested by:

- Implementing unit tests for the new /v2/locks/status 'GET' operation
- Spinning up a local instance of HSM in a docker-compose environment, manually populating it with components and setting locks, and executing calls with various query parameters specified
- Upgrading the running HSM service on Mug using Helm to deploy the new version and testing the new functionality using the HSM data from a production environment
- Verifying that the HSM CT smoke and functional tests continued to pass

Was a fresh Install tested? Partially, via a fresh local instance of HSM
Was an Upgrade tested? Y, using Helm
Was a Downgrade tested? Y, using Helm

### Risks and Mitigations

Fairly low risk since this change adds new functionality. Changes that could impact existing HSM /locks/status APIs due to the use of shared functions are minimal and were verified by confirming that their unit tests continued to pass.