### PR TITLE
CASMINST-4265: Bump goss-servers to 1.12.19

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.31
 
 # CSM Testing Utils
-goss-servers=1.12.17-1
+goss-servers=1.12.19-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
## Summary and Scope

This adds the goss-switch-bgp-neighbor-aruba-or-mellanox.yaml test to ncn-upgrade-preflight-tests.yaml suite.  This allows us to check the BGP peering sessions before we attempt to boot nodes.

## Issues and Related PRs

* Resolves CASMINST-4265

## Testing

### Tested on:

  * `drax`

### Test description:

I manually added this test to the ncn-upgrade-preflight-tests.yaml suite and ran the suite as it is done in prerequisites.sh.   I verified that the test ran and checked the logs for the test in /opt/cray/tests/install/logs/bgp_neighbors_established.

```
GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-preflight-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable