### PR TITLE
CASMINST-4324: update index to pull in v1.12.20 released version of g…

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.32
 
 # CSM Testing Utils
-goss-servers=1.12.19-1
+goss-servers=1.12.20-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
Update to base.packages to pull in v1.12.20 released version of goss-servers
This pulls in changes for:
* CASMINST-4324

### Summary and Scope
1.2 - CASMINST-4324: Remove goss-basecamp-json-ncns.yaml test from ncn-upgrade-preflight-tests suite

Remove goss-basecamp-json-ncns.yaml test from ncn-upgrade-preflight-tests suite.
Update the goss-basecamp-json-ncns.yaml test with pipefail check to prevent false positive result.
Validate updated test on wasp, 1.2.5-alpha.1