### PR TITLE
CASMINST-4142: Update goss-servers to v1.6.53

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -21,7 +21,7 @@ mdadm=4.1-15.32.1
 canu=0.0.5~alpha~2~master.852bef9-1
 
 # CSM Testing Utils
-goss-servers=1.6.51-1
+goss-servers=1.6.53-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION

## Summary and Scope

A change was put in to add `set -e` to the top of the livecd-preflight-check script.  When `/usr/bin/goss validate -f json` is run in that script to execute all of the goss tests in that suite, it will return non-zero if any of the tests fail.  The `set -e` causes the script to then stop execution immediately without giving any output indicating which tests failed.   We need to run `/usr/bin/goss validate -f json` without the `set -e`.

## Issues and Related PRs

* Resolves CASMINST-4142

## Testing

### Tested on:

  * `drax`

### Test description:

I ran `/opt/cray/tests/install/livecd/automated/livecd-preflight-checks` on drax with this fix and injected a test failure I was able to see the test results include the one test that was failing.



## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
