### PR TITLE
CASMINST-4372 CSI fix for CHN reservations (main)

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -8,7 +8,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.16.7-1
+cray-site-init=1.16.9-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.2.3-1


### PR DESCRIPTION
## Summary and Scope

Cray Site Init generated CHN reservations with xname rather than common name. This created two xname records in DNS and played havoc with SAT and DVS.  Additionally UANs were missing from the CHN.  This change remediates these two issues for new/fresh installs of CSM 1.2 where the system has a CHN.

## Issues and Related PRs

* Resolves CASMINST-4372

## Testing

### Tested on:

  * Hela data (has a CHN)
  * Surtur data (does not have a CHN)

### Test description:

Ensured common names were generated in CHN SLS reservations and that UAN entries were generated in the CHN SLS structured.

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
