### PR TITLE
CASMINST-3985: Remove defunct repositories and references

### DIFF
--- a/build/list-files.sh
+++ b/build/list-files.sh
@@ -20,9 +20,6 @@ while [[ $# -gt 0 ]]; do
         list-hpe-spp-repos-files
         list-cray-repos-files
         ;;
-    compute-repos|compute-repositories)
-        list-cray-compute-repos-files
-        ;;
     pkgs|packages)
         list-packages-files
         ;;

--- a/repos/cray-compute.repos
+++ b/repos/cray-compute.repos
@@ -1,3 +1,0 @@
-http://car.dev.cray.com/artifactory/csm/CLOUD/sle15_sp3_cn/x86_64/dev/master/  cray-csm-sle-15sp3-compute-x86_64-CLOUD-1.2  --gpgcheck-allow-unsigned-repo -p 89  cray/csm/sle-15sp3-compute/x86_64
-http://car.dev.cray.com/artifactory/csm/SCMS/sle15_sp3_cn/x86_64/dev/master/   cray-csm-sle-15sp3-compute-x86_64-SCMS-1.2   --gpgcheck-allow-unsigned-repo -p 89  cray/csm/sle-15sp3-compute/x86_64
-http://car.dev.cray.com/artifactory/csm/UAS/sle15_sp3_cn/x86_64/dev/master/    cray-csm-sle-15sp3-compute-x86_64-UAS-1.0    --gpgcheck-allow-unsigned-repo -p 89  cray/csm/sle-15sp3-compute/x86_64

--- a/scripts/rpm-functions.sh
+++ b/scripts/rpm-functions.sh
@@ -45,12 +45,6 @@ ${CSM_RPMS_DIR}/repos/cray.repos
 EOF
 }
 
-function list-cray-compute-repos-files() {
-  cat <<EOF
-${CSM_RPMS_DIR}/repos/cray-compute.repos
-EOF
-}
-
 function remove-comments-and-empty-lines() {
   sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "$@"
 }
@@ -78,15 +72,8 @@ function add-cray-repos() {
   list-cray-repos-files | xargs -r cat | zypper-add-repos
 }
 
-function add-cray-compute-repos() {
-  list-cray-compute-repos-files | xargs -r cat | zypper-add-repos
-}
-
 function setup-package-repos() {
   case "$1" in
-  -c|--compute)
-    add-cray-compute-repos
-    ;;
   *)
     add-hpe-repos
     add-cray-repos


### PR DESCRIPTION
## Summary and Scope

The repos at `car.dev.cray.com` are being removed. This PR removes references to those repos and the functions that installed those repos.

## Issues and Related PRs


* Resolves [CASMINST-3985](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3985)

## Testing

### Tested on:

  * Local development environment

### Test description:

Built `node-image-build` NCN images locally.

## Risks and Mitigations

Risk that the cray-compute functions are needed for other work.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

