### PR TITLE
CASMINST-3985 - Adjust package upgrades to no longer rely on removed repos.

### DIFF
--- a/scripts/update-package-versions.sh
+++ b/scripts/update-package-versions.sh
@@ -84,7 +84,6 @@ do
       ;;
     -c|--compute)
       DOCKER_CACHE_IMAGE="${DOCKER_CACHE_IMAGE}-compute"
-      SETUP_PACKAGE_REPOS_FLAGS="--compute"
       ;;
     -o|--output-diffs-only)
       OUTPUT_DIFFS_ONLY="true"
@@ -123,7 +122,7 @@ if [[ "$(docker images -q $DOCKER_CACHE_IMAGE 2> /dev/null)" == "" ]]; then
     source /app/scripts/rpm-functions.sh
     zypper --non-interactive install gettext gawk
     cleanup-all-repos
-    setup-package-repos $SETUP_PACKAGE_REPOS_FLAGS
+    setup-package-repos
     zypper refresh
     # Force a cache update
     zypper --no-refresh info man > /dev/null 2>&1


### PR DESCRIPTION
## Summary and Scope

A specific compute repos file no longer exists. This removes a call to a non-existent file.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-3985](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3985)

## Testing

### Tested on:

  * Local development environment

### Test description:

- Built `node-image-build` locally.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

