### PR TITLE
CASMINST-4394: update index to pull in v1.12.22 released version of g…

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.32
 
 # CSM Testing Utils
-goss-servers=1.13.0-1
+goss-servers=1.12.22-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
Update to base.packages to pull in v1.12.22 released version of goss-servers
This pulls in changes for:
* CASMINST-4394

### Summary and Scope
main - CASMINST-4394: TESTS: After CSM Services Upgrade, stage 3, should validate at this point.

New ncn-post-csm-service-upgrade-tests.yaml test suite to validate CSM services after upgrade stage3.
Update the goss-k8s-istio-endpoint.yaml, goss-k8s-istio-pod-containers-running.yaml and
goss-k8s-istio-pods-running.yaml tests with pipefail check to prevent false test results.
Validate new suite and updated tests on wasp, 1.2.5-alpha.1

### Issues and Related PRs
CASMINST-4394

### Testing
Tested on wasp with 1.2.5-alpha.1
