### PR TITLE
MTL-1665 Add Missing Packages

### DIFF
--- a/packages/node-image-storage-ceph/base.packages
+++ b/packages/node-image-storage-ceph/base.packages
@@ -1,10 +1,12 @@
 # Base
-python3-boto3=1.17.9-19.1
-python3-kubernetes=8.0.1-3.5.1
-python3-six=1.14.0-10.1
-python3-netaddr=0.7.19-1.17
-netcat-openbsd=1.178-1.24
+cephadm=15.2.15.83+gf72054fa653-3.34.1
 jq=1.6-3.3.1
-cephadm=15.2.14.84+gb6e5642e260-3.31.1
+netcat-openbsd=1.178-1.24
 podman-cni-config=3.4.4-150300.9.3.2
 podman=3.4.4-150300.9.3.2
+python3-boto3=1.18.7-23.4.1
+python3-botocore=1.21.7-37.4.1
+python3-kubernetes=8.0.1-3.5.1
+python3-netaddr=0.7.19-1.17
+python3-s3transfer=0.5.0-9.4.1
+python3-six=1.14.0-12.1


### PR DESCRIPTION
These packages were/are installed in the ceph image but should be installed via csm-rpms.

This also alpha-sorts the packages in this file.

Once this merges then these can be pulled from the storage-ceph image provisioner.

PR removing these from the NCN is here: https://github.com/Cray-HPE/node-image-build/pull/226