### PR TITLE
CASMINST-4435: move compute repos in cray list to compute list

### DIFF
--- a/repos/cray-compute.repos
+++ b/repos/cray-compute.repos
@@ -1,3 +1,5 @@
 http://car.dev.cray.com/artifactory/csm/CLOUD/sle15_sp3_cn/x86_64/dev/master/  cray-csm-sle-15sp3-compute-x86_64-CLOUD-1.2  --gpgcheck-allow-unsigned-repo -p 89  cray/csm/sle-15sp3-compute/x86_64
 http://car.dev.cray.com/artifactory/csm/SCMS/sle15_sp3_cn/x86_64/dev/master/   cray-csm-sle-15sp3-compute-x86_64-SCMS-1.2   --gpgcheck-allow-unsigned-repo -p 89  cray/csm/sle-15sp3-compute/x86_64
 http://car.dev.cray.com/artifactory/csm/UAS/sle15_sp3_cn/x86_64/dev/master/    cray-csm-sle-15sp3-compute-x86_64-UAS-1.0    --gpgcheck-allow-unsigned-repo -p 89  cray/csm/sle-15sp3-compute/x86_64
+https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_cn/                          cray-cos-sle-15sp3-SHASTA-cos-2.2                 --no-gpgcheck -p 59                   cray/cos/sle-15sp3-cn
+https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.1/sle15_sp2_cn/                          cray-cos-sle-15sp2-SHASTA-cos-2.1                 --no-gpgcheck -p 69                   cray/cos/sle-15sp2-cn

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -1,9 +1,6 @@
 https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_ncn/                         cray-cos-sle-15sp3-SHASTA-OS-cos-2.2              --no-gpgcheck -p 59                   cray/cos/sle-15sp3-ncn
 https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.1/sle15_sp2_ncn/                         cray-cos-sle-15sp2-SHASTA-OS-cos-2.1              --no-gpgcheck -p 69                   cray/cos/sle-15sp2-ncn
 
-https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_cn/                          cray-cos-sle-15sp3-SHASTA-cos-2.2                 --no-gpgcheck -p 59                   cray/cos/sle-15sp3-cn
-https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.1/sle15_sp2_cn/                          cray-cos-sle-15sp2-SHASTA-cos-2.1                 --no-gpgcheck -p 69                   cray/cos/sle-15sp2-cn
-
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/                                        cray-algol60-csm-rpms-stable-sle-15sp3            --no-gpgcheck -p 59                   cray/csm/sle-15sp3
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/                                        cray-algol60-csm-rpms-stable-sle-15sp2            --no-gpgcheck -p 69                   cray/csm/sle-15sp2
 


### PR DESCRIPTION
## Summary and Scope

These compute node repos were breaking the PIT iso build. Move
them to the file where the rest of the compute repos live.