### PR TITLE
CASMINST-4283:  Bump CSI version to 1.16.11

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -8,7 +8,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.16.7-1
+cray-site-init=1.16.11-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.2.4-1


### PR DESCRIPTION
#### Summary and Scope
We need prevent UAIs from getting to CMN like we do with NMNLB.   The way this is being accomplished with NMNLB is that a route exists on the UAI that goes to a gateway that it cannot get to.   We are doing the same thing for CMN by adding the CMN subnet to macvlan routes defined in customizations.yaml.  This causes it to be added to the relevant network attachment definitions.

- Fixes #CASMINST-4283

#### Prerequisites

- [x] I tested this on my laptop

I did a local build of CSI.  I ran "csi config init" with the resulting binary using the seed files from hela.   I verified that the correct CMN route (10.103.0.0./25) was added to the customizations.yaml generated by CSI.

```
  macvlansetup:
    nmn_subnet: 10.252.2.0/23
    nmn_supernet: 10.252.0.0/17
    nmn_supernet_gateway: 10.252.0.1
    nmn_vlan: bond0.nmn0
    nmn_reservation_start: 10.252.2.10
    nmn_reservation_end: 10.252.3.254
    routes:
    - dst: 10.100.0.0/17
      gw: 10.252.0.1
    - dst: 10.106.0.0/17
      gw: 10.252.0.1
    - dst: 10.103.0.0/25
      gw: 10.252.0.1
    - dst: 10.92.100.0/24
      gw: 10.252.0.1
```
 