### PR TITLE
Move COS repos out of cray.repos

### DIFF
--- a/repos/cos.repos
+++ b/repos/cos.repos
@@ -1,0 +1,4 @@
+https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_ncn/                         cray-cos-sle-15sp3-SHASTA-OS-cos-2.2              --no-gpgcheck -p 59                   cray/cos/sle-15sp3-ncn
+https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.1/sle15_sp2_ncn/                         cray-cos-sle-15sp2-SHASTA-OS-cos-2.1              --no-gpgcheck -p 69                   cray/cos/sle-15sp2-ncn
+https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_cn/                          cray-cos-sle-15sp3-SHASTA-cos-2.2                 --no-gpgcheck -p 59                   cray/cos/sle-15sp3-cn
+https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.1/sle15_sp2_cn/                          cray-cos-sle-15sp2-SHASTA-cos-2.1                 --no-gpgcheck -p 69                   cray/cos/sle-15sp2-cn

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -1,9 +1,3 @@
-https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_ncn/                         cray-cos-sle-15sp3-SHASTA-OS-cos-2.2              --no-gpgcheck -p 59                   cray/cos/sle-15sp3-ncn
-https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.1/sle15_sp2_ncn/                         cray-cos-sle-15sp2-SHASTA-OS-cos-2.1              --no-gpgcheck -p 69                   cray/cos/sle-15sp2-ncn
-
-https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.2/sle15_sp3_cn/                          cray-cos-sle-15sp3-SHASTA-cos-2.2                 --no-gpgcheck -p 59                   cray/cos/sle-15sp3-cn
-https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.1/sle15_sp2_cn/                          cray-cos-sle-15sp2-SHASTA-cos-2.1                 --no-gpgcheck -p 69                   cray/cos/sle-15sp2-cn
-
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/                                        cray-algol60-csm-rpms-stable-sle-15sp3            --no-gpgcheck -p 59                   cray/csm/sle-15sp3
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/                                        cray-algol60-csm-rpms-stable-sle-15sp2            --no-gpgcheck -p 69                   cray/csm/sle-15sp2
 

--- a/scripts/rpm-functions.sh
+++ b/scripts/rpm-functions.sh
@@ -45,6 +45,12 @@ ${CSM_RPMS_DIR}/repos/cray.repos
 EOF
 }
 
+function list-cos-repos-files() {
+  cat <<EOF
+${CSM_RPMS_DIR}/repos/cos.repos
+EOF
+}
+
 function list-cray-compute-repos-files() {
   cat <<EOF
 ${CSM_RPMS_DIR}/repos/cray-compute.repos
@@ -78,6 +84,10 @@ function add-cray-repos() {
   list-cray-repos-files | xargs -r cat | zypper-add-repos
 }
 
+function add-cos-repos() {
+  list-cos-repos-files | xargs -r cat | zypper-add-repos
+}
+
 function add-cray-compute-repos() {
   list-cray-compute-repos-files | xargs -r cat | zypper-add-repos
 }
@@ -87,10 +97,16 @@ function setup-package-repos() {
   -c|--compute)
     add-cray-compute-repos
     ;;
+  -p|--pit)
+    add-hpe-repos
+    add-cray-repos
+    add-suse-repos
+    ;;
   *)
     add-hpe-repos
     add-cray-repos
     add-suse-repos
+    add-cos-repos
     ;;
   esac
 


### PR DESCRIPTION
## Summary and Scope

The COS repos were causing problems for PIT ISO builds due to
conflicting compute-node kernel RPMs in those COS repos.  Split
out COS repos into their own file and add a `--pit` option to
`setup-packages-repos` to allow skipping COS repos for PIT builds.