### PR TITLE
casmpet-5479: remove references to no longer existing etcd selfLink m…

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -3,7 +3,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 ipvsadm=1.29-4.3.1
 python3-boto3=1.17.9-19.1
-platform-utils=1.2.2-1
+platform-utils=1.2.8-1
 cray-cmstools-crayctldeploy=1.3.3-1
 rpm-build=4.14.3-37.2
 


### PR DESCRIPTION
Update to kubernets packages to pull in platform-utils=1.2.8-1
This pulls in changes for:
* CASMPET-5479

### Summary and Scope
Master - CASMPET-5479: Remove references to no longer existing etcd selfLink metadata attribute.

With new versions of etcd and kubernetes in 1.2, the etcd selfLink metadata atribute is no longer in use. As a result all etcd restore/rebuild operations fail. Remove references to selfLink metadata atribute in edit_yaml_for_rebuild.py.

At same time:
Add missing exit in move_pods.sh help function.
Enable ncnHealthchecks.sh tool to report csm version on system.
Use dynamic PROGNAME in grafterm.sh rather than hardcoded "grafterm".

Validate updated utilities on mug, csm 1.2.0-beta.52 and drax, csm 1.2.0-beta.104, and on wasp, 1.2.0-beta.102, with CASMINST-4465 fixes applied.

### Issues and Related PRs
CASMPET-5479

### Testing
Validated on mug, csm 1.2.0-beta.52 and drax, csm 1.2.0-beta.104, and on wasp, 1.2.0-beta.102, with CASMINST-4465 fixes applied.
