### PR TITLE
CASMNET-1518: CANU Release 1.5.6 (main)

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -1,6 +1,6 @@
 # CSM Packages
 apache2=2.4.43-3.25.1
-canu=1.3.2-1
+canu=1.5.6-1
 craycli=0.46.0
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.32

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -1,6 +1,6 @@
 #CSM
 acpid=2.0.31-1.1
-canu=1.3.2-1
+canu=1.5.6-1
 cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
 craycli=0.46.0


### PR DESCRIPTION
## Summary and Scope

- Feature:  LAG preserve to help in adopting CANU
- Feature:  Send arbitrary read-only commands to switches.
- Many switch configuration template fixes.
- Many docs updates and changes.

## Issues and Related PRs

[Release Notes](https://github.com/Cray-HPE/canu/releases/1.5.6)

* Resolves CASMNET-1518

## Testing

These changes have soaked in development and been used on multiple internal systems for up to several weeks.

### Tested on:

  * Nox testing
  * Gamora, Jolt1, Wasp and a large customer environment

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

