### PR TITLE
Add kubectl hns plugin for CSM 1.3

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -2,6 +2,7 @@
 acpid=2.0.31-1.1
 canu=1.3.2-1
 cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
+cray-kubectl-hns-plugin=1.0.0-1
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
 craycli=0.46.0
 csm-node-identity=1.0.18-1


### PR DESCRIPTION
## Summary and Scope

Install binary on NCNs to support hierarchical namespace management via `kubectl hns *` commands.  This feature is targeted towards post-1.3, however we don't want to require an NCN image for this feature.  Installing the binary in 1.3 NCN images will be benign.

## Issues and Related PRs

* Resolves [CASMINST-4297](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4297)

## Testing

```
ncn-m003-eef2744f:~ # kubectl hns tree tenants
Error: unknown command "hns" for "kubectl"
Run 'kubectl --help' for usage.
```

```
ncn-m003-eef2744f:~ # rpm -Uvh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/cray-kubectl-hns-plugin/x86_64/cray-kubectl-hns-plugin-1.0.0-1.x86_64.rpm
Retrieving https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/cray-kubectl-hns-plugin/x86_64/cray-kubectl-hns-plugin-1.0.0-1.x86_64.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:cray-kubectl-hns-plugin-1.0.0-1  ################################# [100%]
```

```
ncn-m003-eef2744f:~ # kubectl hns tree tenants
tenants
└── [s] tenant-dev
    ├── [s] tenant-dev-slurm
    └── [s] tenant-dev-user

[s] indicates subnamespaces
```


### Tested on:

  * `vshata`

### Test description:

Tested installing the rpm on vshasta.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

