### PR TITLE
Podman updates / reattempt

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -10,11 +10,11 @@ manifestgen=1.3.4-1~development~bbba190
 # CSM METAL-team Packages
 cray-site-init=1.16.13-1
 ilorest=3.2.3-1
-metal-basecamp=1.1.10-1
+metal-basecamp=1.1.11-1
 metal-ipxe=2.2.4-1
 metal-net-scripts=0.0.2-1
 pit-init=1.2.19-1
-pit-nexus=1.1.1-1
+pit-nexus=1.1.2-1
 
 # SUSE Packages
 acl=2.2.52-4.3.1


### PR DESCRIPTION
Includes further updates for podman dependent packages such as pit-nexus and metal-basecamp to work with podman3.