### PR TITLE
casmpet-5560: specify first field returned to correct 13h not found e…

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -3,7 +3,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 ipvsadm=1.29-4.3.1
 python3-boto3=1.17.9-19.1
-platform-utils=1.2.8-1
+platform-utils=1.2.9-1
 cray-cmstools-crayctldeploy=1.3.3-1
 rpm-build=4.14.3-37.2
 


### PR DESCRIPTION
Update to kubernets packages to pull in platform-utils=1.2.9-1
This pulls in changes for:
    CASMPET-5560

### Summary and Scope
Master - CASMPET-5560: specify first field returned to correct 13h not found error.

Only keep/use the first field returned.

Validate updated utilities on drax, csm 1.2.0-rc.1 and wasp, 1.2.0-beta.102, with CASMINST-5560 fix applied.

### Issues and Related PRs
CASMPET-5560

### Testing
Validated on drax, csm 1.2.0-rc.1 and wasp, 1.2.0-beta.102.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A
