### PR TITLE
CASMINST-4533 Grab pit-init with yq binary

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -4,6 +4,7 @@ canu=1.5.7-1
 craycli=0.46.0
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.32
+hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 
@@ -13,7 +14,7 @@ ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.2.5-1
 metal-net-scripts=0.0.2-1
-pit-init=1.2.18-1
+pit-init=1.2.19-1
 pit-nexus=1.1.0-1.1
 
 # SUSE Packages


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

This includes the `yq` package, and a small tweak from pit-init 1.2.19. If `/usr/bin/yq` exists, it'll be a symlink not a file. The current -f test fails to find it if it exists. This change tests for its existence with command.

This also sets up the need for `CSM_PATH` only when `/usr/bin/yq` is not present.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

No.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-4533](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4533)
* **This change is already in `main`**

