### PR TITLE
Add patroni service restarts for lagging PG members before checking lag

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.32
 
 # CSM Testing Utils
-goss-servers=1.12.22-1
+goss-servers=1.12.27-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
## Summary and Scope

Add service restart for patroni service in lagging members before validating lag (required when bouncing masters due to backoff in postgres pods that's not tunable), as well as correct lag check to exec into the leader.

## Issues and Related PRs

* Resolves [CASMINST-4544](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4544)

## Testing

Ran many times on surter when rebuilding master node.

### Tested on:

  * `surtur`

### Test description:

Ran many times

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable