### PR TITLE
CASMTRIAGE-3253:  Bump CSI version to 1.16.16

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -9,7 +9,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.16.13-1
+cray-site-init=1.16.16-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.2.6-1


### PR DESCRIPTION
#### Summary and Scope

- Fixes #CASMTRIAGE-3253

##### Issue Type

- Bugfix Pull Request

Renames the uai_macvlan_bridge reservation in the uai_macvlan subnet to uai_nmn_blackhole.   uai_macvlan_bridge is no longer being used.  We are repurposing that reservation to be used as the gw for the NMNLB route in UAIs.  This will block access to the NMNLB from the UAI.

While in the same same section of code, I also made the allocation of IPs to the uai_macvlan reservations consistent.  This solves the issue with running CSI multiple times and ending up with different IPs for these reservations.


##### Testing

Built CSI locally and ran the `csi config init` with seed files from hela.   Checked the generated sls_input_file.json and customizations.yaml. 

