### PR TITLE
MTL-1710 Fix freshinstall issue with configure-ntp

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -14,7 +14,7 @@ ilorest=3.2.3-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.2.6-1
 metal-net-scripts=0.0.2-1
-pit-init=1.2.19-1
+pit-init=1.2.21-1
 pit-nexus=1.1.0-1.1
 
 # SUSE Packages


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1710

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

This fixes the following errors if `pit-init` is invoked on a fresh install where `data.json` does not exist yet.

```bash
= PIT Identification = COPY/CUT END =========================================
Setting up NTP ...
cat: /var/www/ephemeral/configs/data.json: No such file or directory
cat: /var/www/ephemeral/configs/data.json: No such file or directory
cat: /var/www/ephemeral/configs/data.json: No such file or directory
cat: /var/www/ephemeral/configs/data.json: No such file or directory
cat: /var/www/ephemeral/configs/data.json: No such file or directory 
```

The change moves the `configure-ntp` call after `data.json` is copied into place.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 

#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
What is less risky, or more risky now - or if your mod fails is there a new risk?

This is less risky since it ensures `configure-ntp` uses a current `data.json`.