### PR TITLE
CASMINST-4549 main

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -9,7 +9,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.17.1-1
+cray-site-init=1.17.2-1
 ilorest=3.2.3-1
 metal-basecamp=1.1.12-1
 metal-ipxe=2.2.6-1


### PR DESCRIPTION
## Summary and Scope

- In order to have interoperability between the HMN-SHCD parser and CANU we need to be able to have 0 as a destination port number on the HMN tab of the SHCD.
- This change allows SLS to accept 0 as a port number.  This is the same behavior as leaving it blank.


- Fixes # CASMINST-4549

## Testing

Tested locally.  All tests passed.
Generated SLS file has no differences with a "" or "0" as port destination.
