### PR TITLE
CASMINST-4565/CASMINST-4576: Goss test improvements

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -8,7 +8,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.32
 
 # CSM Testing Utils
-goss-servers=1.12.27-1
+goss-servers=1.12.30-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
[CASMINST-4565](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4565) Enhance kube-system Goss test to remove need for manual test during Deploy Management Nodes install procedure.
[CASMINST-4576](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4576) Validate that ceph -s works where and when it ought to. This would have caught a problem on the gamora install much earlier and saved hours of time.

See source PRs for full details:
https://github.com/Cray-HPE/csm-testing/pull/301
https://github.com/Cray-HPE/csm-testing/pull/304
