### PR TITLE
MTL-1695 Less requirements

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -14,7 +14,7 @@ ilorest=3.2.3-1
 metal-basecamp=1.1.12-1
 metal-ipxe=2.2.6-1
 metal-net-scripts=0.0.2-1
-pit-init=1.2.21-1
+pit-init=1.2.22-1
 pit-nexus=1.1.4-1
 
 # SUSE Packages


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Relates to MTL-1695

##### Issue Type
<!--- Delete un-needed bullets -->

- Docs Pull Request
- RFE Pull Request

These requirement for `IPMI_PASSWORD` and `SYSTEM_NAME` are unnecessary.

1. `IPMI_PASSWORD` is needed for `set-sqfs-links.sh`, but that script is not invoked by `pit-init.sh`.
2. `SYSTEM_NAME` is necessary for `csi config init` but `pit-init` expects a `system_config.yaml` file to exist with `system-name:` defined.

Removing these two vars will enable `pit-init.sh` to be invoked without exporting 2 variables prior, currently docs mandate these exports. MTL-1695 is removing the exports.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 

#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
What is less risky, or more risky now - or if your mod fails is there a new risk?
