### PR TITLE
MTL-1476 Fix Builds

### DIFF
--- a/packages/cray-pre-install-toolkit/metal.packages
+++ b/packages/cray-pre-install-toolkit/metal.packages
@@ -8,7 +8,6 @@ kernel-source=5.3.18-150300.59.63.1
 kernel-syms=5.3.18-150300.59.63.1
 kernel-mft-mlnx-kmp-default=4.18.0_k5.3.18_57-1.sles15sp3
 ledmon=0.94-1.59
-SLE_HPC-release=15.3-47.3.3
 # DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"
 mft=4.18.0-106
 tpm2.0-abrmd=2.3.3-3.3.1


### PR DESCRIPTION
SLE_HPC-release is handled in a provisioner for pit-common. The node-image-build repo handles this RPM differently than
cray-pre-install-toolkit, and having this here actually breaks the zypper command due to a conflict.

cray-pre-install-toolkit already has this package specified in its config.xml file, it doesn't need to have it in csm-rpms.

Removing this will maintain the HPC integrity while enabling MTL-1476 builds.
