### PR TITLE
CASMTRIAGE-3363 include ilorest in all node images for bios/firmware …

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -46,6 +46,7 @@ gperftools=2.5-4.12
 gptfdisk=1.0.1-2.11
 hdparm=9.52-1.22
 hplip=3.20.11-2.1
+ilorest=3.5.0-1
 ipmitool=1.8.18+git20200204.7ccea28-3.3.1
 iproute2-bash-completion=5.3-5.2.1
 ipset=6.36-3.3.1


### PR DESCRIPTION
…check

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Adds `ilorest` to the NCN images, not just PIT.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially resolves CASMTRIAGE-3363
* Merge with https://github.com/Cray-HPE/csm-testing/pull/319
* Merge with https://github.com/Cray-HPE/csm/pull/843

## Testing

Testing results seen in https://github.com/Cray-HPE/csm-testing/pull/319

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

