### PR TITLE
CASMINST-4745 MTL-1787

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -15,7 +15,7 @@ ilorest=3.5.0-1
 metal-basecamp=1.1.13-1
 metal-ipxe=2.2.7-1
 metal-net-scripts=0.0.2-1
-pit-init=1.2.24-1
+pit-init=1.2.26-1
 pit-nexus=1.1.4-1
 
 # SUSE Packages


### PR DESCRIPTION
Pulls in:
- CASMINST-4745: bios-baseline fix for default prompt (https://github.com/Cray-HPE/pit-init/pull/38)
- MTL-1787: pit-init reorg (https://github.com/Cray-HPE/pit-init/pull/39)