### PR TITLE
canu release 1.6.1 (rel/1.2)

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -1,6 +1,6 @@
 # CSM Packages
 apache2=2.4.43-3.25.1
-canu=1.5.12-1
+canu=1.6.1-1
 craycli=0.46.0
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.33-1

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -1,6 +1,6 @@
 #CSM
 acpid=2.0.31-1.1
-canu=1.5.12-1
+canu=1.6.1-1
 cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
 craycli=0.46.0


### PR DESCRIPTION
## Summary and Scope

Upgrading Canu from 1.5.7 to 1.6.1.

    Disable load balacing configuration for Dell CDU/Leaf.
    Add canu report network version feature.
    Fix Errors in the output of canu test
    Add route-map and prefixes to allow connection to UAI's from CAN network.
    Fix Dell4148 template to include correct port count

## Issues and Related PRs

https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3322
https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1572

## Testing

Nox, surtur, drax

### Test description:

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

