### PR TITLE
CASMINST-4770 Use algol60 mirrors

### DIFF
--- a/repos/suse.template.repos
+++ b/repos/suse.template.repos
@@ -79,6 +79,6 @@ https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifac
 # haproxy and keepalived:
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Backports/SLE-15-SP2_x86_64/standard?auth=basic                                 SUSE-Backports-SLE-15-SP2-x86_64                                      -g -p 89  suse/Backports-SLE/15-SP2/x86_64/standard
 
-# FIXME: CASMINST-4770 Use algol60 URLs.
-https://download.opensuse.org/repositories/openSUSE:Backports:SLE-15-SP3/step/                                                                                                   openSUSE-Backports-SLE-15-SP3                                         -g -p 89  step/
-https://download.opensuse.org/repositories/filesystems:ceph/openSUSE_Leap_15.3/                                                                                                  filesystems-ceph                                                      -g -p 89  openSUSE_Leap_15.3/
+# cephadm, ceph-common, and libfmt7
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/openSUSE:Backports:SLE-15-SP3/step/                                         openSUSE-Backports-SLE-15-SP3                                         -g -p 89  step/
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/filesystems:ceph/openSUSE_Leap_15.3/                                        filesystems-ceph                                                      -g -p 89  openSUSE_Leap_15.3/


### PR DESCRIPTION
This is a followup PR to #435 that uses the new algol60 repos.