### PR TITLE
HPCCHT3-3210 redo

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -29,7 +29,7 @@ hms-sls-ct-test=1.18.0-1
 hms-smd-ct-test=1.50.0-1
 
 # SDU
-cray-sdu-rda-2.0.0-shasta_20220512140700_f3c40fd
+cray-sdu-rda=2.0.0-shasta_20220512140700_f3c40fd
 
 # SAT
 cray-prodmgr=1.1.2-20220104153307_2374f1f


### PR DESCRIPTION
PR #416 did not correctly update the sdu-rda package, the package did end up getting into an NCN image but it appears broken when csm-rpms update scripts run.

This PR simply corrects the previous PR and ensures that cray-sdu-rda is defined properly.