### PR TITLE
MTL-1790 Add vshasta packages

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -44,6 +44,7 @@ pipeline {
         sh """
           ./scripts/update-package-versions.sh -p packages/node-image-non-compute-common/base.packages --validate --suffix ${env.SUFFIX}
           ./scripts/update-package-versions.sh -p packages/node-image-non-compute-common/cms.packages --validate --suffix ${env.SUFFIX}
+          ./scripts/update-package-versions.sh -p packages/node-image-non-compute-common/google.packages --validate --suffix ${env.SUFFIX}
           ./scripts/update-package-versions.sh -p packages/node-image-non-compute-common/metal.packages --validate --suffix ${env.SUFFIX}
         """
       }

--- a/packages/node-image-non-compute-common/google.packages
+++ b/packages/node-image-non-compute-common/google.packages
@@ -1,0 +1,4 @@
+google-guest-agent=20220204.00-150000.1.26.1
+google-guest-configs=20220211.00-150000.1.19.1
+google-guest-oslogin=20220205.00-150000.1.27.1
+google-osconfig-agent=20220209.00-150000.1.17.1


### PR DESCRIPTION
These packages were installed manually in the node-images:google images, this PR moves them from node-images to csm-rpms.

This was supposed to be cleaned up in the original #437 PR but was missed.