### PR TITLE
CASMINST-4720: Add logging to additional Goss tests

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -11,7 +11,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.33-1
 
 # CSM Testing Utils
-goss-servers=1.14.22-1
+goss-servers=1.14.23-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
## Summary and Scope

Update goss-servers to pull in CASMINST-4720, which adds test logging to a handful of Goss tests. See source PR for details:
https://github.com/Cray-HPE/csm-testing/pull/328

## Issues and Related PRs

This is only going into 1.3.
