### PR TITLE
canu 1.6.4 release

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -1,6 +1,6 @@
 # CSM Packages
 apache2=2.4.43-3.25.1
-canu=1.6.1-1
+canu=1.6.4-1
 craycli=0.46.0
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.33-1

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -1,6 +1,5 @@
 #CSM
 acpid=2.0.31-1.1
-canu=1.6.1-1
 cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
 craycli=0.46.0


### PR DESCRIPTION
## Summary and Scope

## Summary and Scope

[1.6.4]

    Documentation updates to docs/network_configuration_and_upgrade

[1.6.3]

    Use full show run commands to retrieve running config from canu network backup
    UAN CAN ports are now shutdown if CHN is enabled.
    Mellanox UAN CAN ports now only allow the CAN vlan.
    Added CMC subrack port configuration.
    Documentation updates to docs/network_configuration_and_upgrade

[1.6.2]

    Correct the 'slot warning' to specify more accurate options

## Issues and Related PRs

[_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMNET-1591](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1591)

## Testing

Nox

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

