### PR TITLE
MTL-1796 Add kubectl to LiveCD base packages

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -39,6 +39,7 @@ iproute2-bash-completion=5.3-5.5.1
 iproute2=5.3-5.5.1
 iputils=s20161105-8.3.1
 jq=1.6-3.3.1
+kubectl=1.21.12-0
 less=530-3.3.2
 lshw=B.02.19.2+git.20210619-3.9.1
 lsof=4.91-1.11


### PR DESCRIPTION
This removes the ad-hoc install of kubectl by leveraging CSM-RPMs. CSM-RPMs now has kubectl listed from the completion of [MTL-1790](https://connect.us.cray.com/jira/browse/MTL-1790).

This also brings kubectl up to the matching version that is used in the NCN images.