### PR TITLE
MTL-1750 Basecamp and CSI Now Use Go1.18

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -10,9 +10,9 @@ loftsman=1.2.0-20211217162356_bf1bdb7
 manifestgen=1.3.5-1~development~9299ac1
 
 # CSM METAL-team Packages
-cray-site-init=1.19.1-1
+cray-site-init=1.20.0-1
 ilorest=3.5.0-1
-metal-basecamp=1.1.13-1
+metal-basecamp=1.2.0-1
 metal-ipxe=2.2.7-1
 metal-net-scripts=0.0.2-1
 pit-init=1.2.26-1


### PR DESCRIPTION
Bring in newer Basecamp and CSI applications, now building with Go1.18.