### PR TITLE
CASMCMS-7876 Update to craycli 0.53.0-1 and pull loftsman/manifestgen from algol60

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -1,13 +1,13 @@
 # CSM Packages
 apache2=2.4.51-150200.3.42.1
 canu=1.6.5-1
-craycli=0.52.0-1
+craycli=0.53.0-1
 dnsmasq=2.86-150100.7.20.1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.34-1
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
-loftsman=1.2.0-20211217162356_bf1bdb7
-manifestgen=1.3.5-1~development~9299ac1
+loftsman=1.2.0-1
+manifestgen=1.3.6-1
 
 # CSM METAL-team Packages
 cray-site-init=1.20.0-1

--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -3,8 +3,8 @@ cray-cmstools-crayctldeploy=1.3.3-1
 ipvsadm=1.29-4.3.1
 kubeadm=1.21.12-0
 kubelet=1.21.12-0
-loftsman=1.2.0-20211217162356_bf1bdb7
-manifestgen=1.3.5-1~development~9299ac1
+loftsman=1.2.0-1
+manifestgen=1.3.6-1
 platform-utils=1.2.9-1
 python3-boto3=1.18.7-23.4.1
 

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -7,7 +7,7 @@ cray-power-button=1.3.1-2.3_20220329162359__g0ddf9af
 # CSM
 cray-kubectl-hns-plugin=1.0.0-1
 cray-kubectl-kubelogin-plugin=1.25.1-1
-craycli=0.52.0-1
+craycli=0.53.0-1
 csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.34-1
 

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -5,6 +5,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/      
 
 https://arti.dev.cray.com/artifactory/sat-rpm-master-local/dev/master/sle15_sp2_ncn/                              cray-sat-sle-15sp2-x86_64-master                  --no-gpgcheck -p 89                   cray/sat/sle-15sp2/x86_64
 
-https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/release/                                               cray-csm-rpm-stable-local-release                 --no-gpgcheck -p 89                   cray/csm/rpm/stable/local/release
-
 https://arti.dev.cray.com/artifactory/sdu-rpm-stable-local/release/img_oci-shasta-2.0/sle15_sp3_ncn/              sdu-rpm-stable-local                              --no-gpgcheck -p 89                   sdu-rpm-stable-local/release/2.0/sle15_sp3_ncn/


### PR DESCRIPTION
- There's a new craycli (0.53.0-1).
- Pulls loftsman from algol60 using a stable/release tag instead of a development version from arti.dev.cray.com
- Pulls manifestgen with a stable RPM name instead of "development" in the name (RPM name was fixed in https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/manifestgen/x86_64/manifestgen-v1.3.6-1.x86_64.rpm)