### PR TITLE
MTL-1288 Automatically wipe NCNs

### DIFF
--- a/packages/node-image-kubernetes/metal.packages
+++ b/packages/node-image-kubernetes/metal.packages
@@ -1,4 +1,4 @@
-dracut-metal-dmk8s=1.7.1-1
-dracut-metal-luksetcd=1.7.1-1
+dracut-metal-dmk8s=2.0.0-1
+dracut-metal-luksetcd=2.0.0-1
 haproxy=2.0.14-bp152.1.1
 keepalived=2.0.19-bp152.1.9

--- a/packages/node-image-non-compute-common/metal.packages
+++ b/packages/node-image-non-compute-common/metal.packages
@@ -1,6 +1,6 @@
 biosdevname=0.7.3-5.3.1
 dracut-kiwi-live=9.24.16-3.47.1
-dracut-metal-mdsquash=1.10.1-1
+dracut-metal-mdsquash=2.0.0-1
 grub2-branding-SLE=15-33.3.1
 grub2-i386-pc=2.04-150300.22.15.2
 grub2-x86_64-efi=2.04-150300.22.15.2


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1288
- Relates to MTL-1654 (removes contention with dmsquash-live)

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

###### Race Conditions Fixes

This adds support for preventing race conditions:

1. Add new paved function to report whether the pave has completed or not. This new function will return 0 or 1 if the wipe is in-progress or has completed, thus allowing dracut modules to wait on the pave before starting their functions.
2. Set `wait_for_dev` locks to wait for the OS disks to ensure dracut waits for this module to finish, preventing dmsquash-live from racing ahead when SQFSRAID is detected. Also remove the previously added labeling code that was working around the race condition, it only worked on the first deployment. Subsequent reboots were susceptible to the race condition. This fix mends the race condition on any boot.

###### Debug Mode

This also fixes missing or broken statements for enabling debug mode. Metal.debug was not honoring `metal.debug=1` in some cases. Ensure all files (except module-setup) honor `metal.debug`.

###### Consider NVME-Only Systems

Also create & use a new disks_exist function, this will ensure we wait for systems with `/dev/sd` or `/dev/nvme` block devices (a mix or pure). Otherwise it was possible to wait forever on systems with only NVME, meaning dracut only worked with mixed systems (SD + NVME, or SD only).

###### Safer Disk Boots

Make disk boots safer by moving the empty metal.server case to its own case that invokes `metal-md-scan`. This case is for disk boots, and only in this case will the mdscan function be used. This move helps separate context when `metal.server` is empty, setting it to empty will ensure none of the disk creation calls are made. When `metal.server` is empty we can assume that disks were already created. This is safer, since none of the disk creation code will load in a disk boot.

###### Misc.

- Add/update licenses.
- Fix broken warn statements, ensure quotes wrap metal_die and warn statements to prevent incorrect warnings.
- Add smarter fstab handling; merge old and new if different on reboot, and after validating they exist.
- When the partition table is unable to inform the kernel of changes, a system reset is performed

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
- [x] I tested rebooting with `metal.no-wipe=0`
- [x] I tested rebooting with `metal.no-wipe=1`
- [x] I tested rebooting with the disk boot loader
- [x] I tested the three scenarios above on k8s-masters, k8s-workers, and storage-ceph

#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
What is less risky, or more risky now - or if your mod fails is there a new risk?

This mitigates the risk of loosing partitions from forgetting to manually wipe, ensuring that any boot from the PIT node will wipe the nodes.

This does pose some risk in-and-of itself being that this is significantly changes the codebase and that this codebase is hard to test.