### PR TITLE
CASMUSER-3028: Update cray-site-init to get changes for net-attach-def HMN routes

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -9,7 +9,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.16.19
+cray-site-init=1.16.19-1
 ilorest=3.5.0-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.2.6-1

--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -9,7 +9,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.4-1~development~bbba190
 
 # CSM METAL-team Packages
-cray-site-init=1.16.18-1
+cray-site-init=1.16.19
 ilorest=3.5.0-1
 metal-basecamp=1.1.9-1
 metal-ipxe=2.2.6-1


### PR DESCRIPTION
## Summary and Scope

See description in csi PR for what was changed:
https://github.com/Cray-HPE/cray-site-init/pull/192/files

New routes for HMN and HMNLB are added to the net-attach-def to blackhole the traffic from a UAI.

## Issues and Related PRs

* Resolves CASMUSER-3028
* Merge after
https://github.com/Cray-HPE/docs-csm/pull/1901
https://github.com/Cray-HPE/cray-site-init/pull/192/files

## Testing

### Tested on:

  * `hermod`
  * Local development environment

### Test description:

I tested this with the net-attach-def set to ipvlan/hsn and macvlan/nmn. I pulled the new routes from a locally built `csi` using hermod seed files. The new routes are shown here:
```
    routes:
    - dst: 10.92.100.0/24        <-- new HMNLB
      gw: 10.252.2.6
    - dst: 10.254.0.0/17        <-- new HMN
      gw: 10.252.2.6
    - dst: 10.101.3.0/25
      gw: 10.252.0.1
    - dst: 10.94.100.0/24
      gw: 10.252.2.6
    - dst: 10.106.0.0/17
      gw: 10.252.0.1
```

With a modified net-attach-def including these routes, I could not hit IPs on those networks as intended. This was done over ipvlan/hsn and macvlan/nmn configurations on hermod.

## Risks and Mitigations

Risk that somehow the routes aren't configured right. Result would be UAIs or WLM pods stuck in ContainerCreating. Mitigation would be to run `kubectl edit -n user net-attach-def` and remove the new routes.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

