### PR TITLE
CASMTRIAGE-3600 SP2 Compatible ilorest

### DIFF
--- a/build/create-index.sh
+++ b/build/create-index.sh
@@ -29,7 +29,7 @@ sed -e '/^Not downloading package /!d' \
     -e "s/^Not downloading package '//" \
     -e 's/[[:space:]]\+.*$//' \
 | sort -u \
-| docker run --rm -i  artifactory.algol60.net/csm-docker/stable/csm-docker-sle:latest rpm-index -v \
+| docker run --rm -i  artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.3 rpm-index -v \
     $(cat "$@" | remove-comments-and-empty-lines | awk '{print "-d", $1, $NF}') \
 | tee "${workdir}/index.yaml"
 

--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -11,7 +11,7 @@ manifestgen=1.3.6-1
 
 # CSM METAL-team Packages
 cray-site-init=1.20.0-1
-ilorest=3.5.0-1
+ilorest=3.5.1-1
 metal-basecamp=1.2.0-1
 metal-ipxe=2.2.7-1
 metal-net-scripts=0.0.2-1

--- a/scripts/update-package-versions.sh
+++ b/scripts/update-package-versions.sh
@@ -87,7 +87,7 @@ REPOS_FILTER="all"
 AUTO_YES="false"
 
 DOCKER_CACHE_IMAGE="csm-rpms-cache"
-DOCKER_BASE_IMAGE="artifactory.algol60.net/csm-docker/stable/csm-docker-sle:latest"
+DOCKER_BASE_IMAGE="artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.3"
 
 while [[ "$#" -gt 0 ]]
 do


### PR DESCRIPTION
Use newer ilorest for CSM 1.3.

This one is also compatible with SLES15SP2 for upgrades if they ever jump from 1.0 to 1.3.