### PR TITLE
pin libctf0 so we stop pulling a newer one in that breaks binutils

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -34,6 +34,7 @@ ethtool=5.14-150400.1.6
 fontconfig=2.13.1-150400.1.4
 fonts-config=20200609+git0.42e2b1b-4.7.1
 git-core=2.35.3-150300.10.12.1
+libctf0=2.37-150100.7.34.1
 libbd_mdraid2=2.26-150400.1.5
 ipmitool=1.8.18.238.gb7adc1d-150400.1.14
 iproute2-bash-completion=5.14-150400.1.8


### PR DESCRIPTION
A newer `libcft0` was being pulled in from the `autoinst.xml`, this caused a conflict when it came time to install `binutils`.

```bash
[ DEBUG   ]: 16:56:04 | Problem: the installed libctf0-2.37-150100.7.37.1.x86_64 requires 'libbfd-2.37.20211103-150100.7.37.so()(64bit)', but this requirement cannot be provided
[ DEBUG   ]: 16:56:04 |  Solution 1: downgrade of libctf0-2.37-150100.7.37.1.x86_64 to libctf0-2.37-150100.7.34.1.x86_64
[ DEBUG   ]: 16:56:04 |  Solution 2: do not install binutils-2.37-150100.7.34.1.x86_64
[ DEBUG   ]: 16:56:04 |  Solution 3: break libctf0-2.37-150100.7.37.1.x86_64 by ignoring some of its dependencies
[ DEBUG   ]: 16:56:04 | Choose from above solutions by number or cancel [1/2/3/c/d/?] (c): c
```

This pins the version so that the conflict won't occur.

This branch resulted in a successful LiveCD build: https://jenkins.algol60.net/job/Cray-HPE/job/cray-pre-install-toolkit/view/tags/job/v1.7.0/6/console