### PR TITLE
MTL-1799, MTL-1818,and MTL-1806

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -15,7 +15,7 @@ ilorest=3.5.1-1
 metal-basecamp=1.2.0-1
 metal-ipxe=2.2.7-1
 metal-net-scripts=0.0.2-1
-pit-init=1.2.26-1
+pit-init=1.2.29-1
 pit-nexus=1.1.4-1
 
 # SUSE Packages


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Add authentication to get-sqfs.sh (MTL-1799), include a bugfix for missing operands (MTL-1818).

Includes a fix for MTL-1806 regarding pit-init when SYSTEM_NAME isn't set.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

