### PR TITLE
MTL-1819 New Dracut fixing no-wipe=1 netboots

### DIFF
--- a/packages/node-image-non-compute-common/metal.packages
+++ b/packages/node-image-non-compute-common/metal.packages
@@ -1,6 +1,6 @@
 biosdevname=0.7.3-5.3.1
 dracut-kiwi-live=9.24.17-150100.3.50.1
-dracut-metal-mdsquash=2.0.1-1
+dracut-metal-mdsquash=2.0.2-1
 grub2-branding-SLE=15-150400.36.12
 grub2-i386-pc=2.06-150400.11.5.2
 grub2-x86_64-efi=2.06-150400.11.5.2


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

This fixes MTL-1819, netboots with `metal.no-wipe=1` were failing. See the original PR's description for technical info: https://github.com/Cray-HPE/dracut-metal-mdsquash/pull/40

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

