### PR TITLE
MTL-1748 Revert + README updates

### DIFF
--- a/packages/node-image-kubernetes/metal.packages
+++ b/packages/node-image-kubernetes/metal.packages
@@ -1,4 +1,4 @@
 dracut-metal-dmk8s=2.0.0-1
-dracut-metal-luksetcd=2.0.0-1
+dracut-metal-luksetcd=2.0.2-1
 haproxy=2.0.14-bp152.1.1
 keepalived=2.0.19-bp152.1.9


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

The luks partition was failing to create in GCP on NVME. The addition from MTL-1748 ends up targeting a partition, but the luks commands need to target the entire disk. Furthermore the partition that's targeted doesn't exist.

This code block had been tested on hermod, but not thoroughly enough. Removing the block was tested on GCP and proved to work.
