### PR TITLE
README and PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+### Summary and Scope
+
+<!--- Pick one below and delete the rest -->
+<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->
+
+- Fixes:
+- Requires:
+- Relates to:
+
+#### Issue Type
+
+<!--- Delete un-needed bullets -->
+
+- Bugfix Pull Request
+- Docs Pull Request
+- RFE Pull Request
+
+<!--- words; describe what this change is and what it is for. -->
+
+### Prerequisites
+
+<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
+<!--- unchecked checkbox: [ ] -->
+<!--- checked checkbox: [x] -->
+<!--- invalid checkbox: [] -->
+
+- [ ] I have included documentation in my PR (or it is not required)
+- [ ] I tested this on internal system (if yes, please include results or a description of the test)
+- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
+
+### Risks and Mitigations
+ 
+<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
+<!--- Example:
+
+This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
+is resolved and the overall risk of fatal failures is reduced.
+
+-->

--- a/README.asc
+++ b/README.asc
@@ -1,5 +1,71 @@
-# Cray System Management - Package & Repository Manifest
+= Cray System Management - Package & Repository Manifest
 
-This repository serves as a docket for which packages
-for which media are desired, as well as which repos to
-select packages from.
+This repository serves as a manifest for CSM's builds of the non-compute node and pre-install toolkit.
+
+Each deliverable is built for multiple mediums, this repository groups manifests by deliverable and the deliverable's
+expected mediums.
+
+== Packages
+
+Packages are sorted based on content and mediums:
+
+=== Content
+
+This list denotes the various content deliverables we build at CSM. Each items in this list has its own list of packages:
+
+- `packages/cray-pre-install-toolkit`
++
+Build Repo: https://github.com/Cray-HPE/cray-pre-install-toolkit
++
+Represents packages on the PIT (a.k.a. pre-install toolkit, or LiveCD)!footnote:disclaimer[`packages/cray-pre-install-toolkit` could rename itself to `packages/node-images-pit-common` after the completion of https://jira-pro.its.hpecorp.net:8443/browse/MTL-1476[MTL-1476]]
+- `packages/node-images-non-compute-common`
++
+Build Repo: https://github.com/Cray-HPE/node-images/tree/develop/boxes/ncn-common
++
+Represents pacakges on the NCN image, common to all NCN images. Adding a package here will ensure it is available in any derivative image (e.g. Kubernetes or Storage-CEPH)
+- `packages/node-images-kubernetes`
++
+Build Repo: https://github.com/Cray-HPE/node-images/tree/develop/boxes/ncn-node-images/kubernetes
++
+Represent packages that exist on the Kubernetes image.
+- `packages/node-images-storage-ceph`
++
+Build Repo: https://github.com/Cray-HPE/node-images/tree/develop/boxes/ncn-node-images/storage-ceph
++
+Represent pacakges that exist on the Storage-CEPH image.
+
+=== Mediums
+
+Each content deliverable builds a Google and a Metal artifact:
+- Google: An artifact delivered to GCP for use in vShasta
+- Metal: An artifact delivered into Artifactory for use on real hardware
+
+.There could be more types of artifacts as time goes on, for now we only build deliverables for Google and Metal.
+
+Each `.package` file in each of the content deliverable folders listed in <<Content>> divide packages up by
+medium (e.g. Google or Metal).
+
+- `base.packages` are common to any build
+- `google.packages` are only installed into Google builds
+- `metal.packages` are only installed into Metal builds
+
+=== Adding Packages
+
+When adding a package, by default any/all packages should go into the `base.packages` file. This helps keep our artifacts common between each delivery endpoint (preventing divergence from Google and Metal).
+If the package is specific to a medium, then it should go into one of the other `.package` files.
+
+==== Examples
+
+For example, `nginx` is necessary in Google to server some data to the vShasta deployment from Kubernetes nodes. However CSM does not want `nginx` installed on metal since it serves
+no purpose for metal installs and would only add an extra unnecessary service. Therefore `nginx` is only installed in Google artifacts of `node-image-kubernetes`.
+
+Another example, `dracut-metal-mdsquash` handles partitioning disks to serve to a booted Live squashFS image. It is a necessity for Metal artifacts, specificlaly the Non-Compute Nodes. However vShasta handles disks entirely differently, and having this package would complicate vshasta
+boots. Therefore it `dracut-metal-mdsquash` is installed in the `node-image-non-compute-common` layer so any NCN derivative will have this package, and it is
+specifically listed in the `metal.packages` file.
+
+An example of a double-inclusion, `keepalived` and `haproxy` are both needed in Kubernetes and Storage-CEPH images and are explicitly listed in both instead of being listed in node-image-non-compute-common.
+This is because if another NCN type were to be created, or if any other node were to import the common layer, that node may not want these two packages. It could be argued that these should exist in ncn-common anyway, but for the sake of not over-specializing the ncn-common layer these remain excluded.
+
+A final example, `cray-site-init` is used for initializing a system in any context. This package is needed in the pre-install toolkit, that is available during an install before non-compute nodes are deployed.
+This package is used for both Metal and vShasta (Google), albeit it might not always be used by developers of vShasta the package itself is usable in either context. Therefore `cray-site-init` is installed into the `cray-pre-install-toolkit` via the `base.packages` file, making it available on both Metal and vShasta PITs.
+

--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -1,3 +1,8 @@
+# Packages common to all mediums.
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).
+
 # CSM Packages
 apache2=2.4.51-150200.3.45.1
 canu=1.6.5-1

--- a/packages/cray-pre-install-toolkit/google.packages
+++ b/packages/cray-pre-install-toolkit/google.packages
@@ -2,4 +2,3 @@
 # Format:
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
-nginx=1.19.8-3.6.1

--- a/packages/cray-pre-install-toolkit/metal.packages
+++ b/packages/cray-pre-install-toolkit/metal.packages
@@ -1,3 +1,7 @@
+# Metal only packages
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).
 amsd=2.4.1-1571.4.sles15
 biosdevname=0.7.3-5.3.1
 grub2-branding-SLE=15-33.3.1

--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -1,4 +1,8 @@
-# Base
+# Packages common to all mediums.
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).
+
 cray-cmstools-crayctldeploy=1.3.3-1
 ipvsadm=1.29-4.3.1
 kubeadm=1.21.12-0
@@ -6,12 +10,13 @@ kubelet=1.21.12-0
 loftsman=1.2.0-1
 manifestgen=1.3.6-1
 platform-utils=1.2.10-1
-python3-boto3=1.18.7-23.4.1
-
 
 # COS
 cray-cps-utils=0.11.0-2.3_20220329162848__gfb2fe6a
 cray-orca=0.9.1-2.3_20220329135308__g8f2d4d6
+
+# DVS
+insserv-compat=0.1-4.6.1
 
 # HMS
 hms-bss-ct-test=1.15.0-1
@@ -33,6 +38,3 @@ cray-sdu-rda=2.0.0-shasta_20220512140700_f3c40fd
 
 # SAT
 cray-prodmgr=1.1.2-20220104153307_2374f1f
-
-# DVS
-insserv-compat=0.1-4.6.1

--- a/packages/node-image-kubernetes/metal.packages
+++ b/packages/node-image-kubernetes/metal.packages
@@ -1,3 +1,8 @@
+# Metal only packages
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).
+
 dracut-metal-dmk8s=2.0.0-1
 dracut-metal-luksetcd=2.0.2-1
 haproxy=2.0.14-bp152.1.1

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -1,22 +1,8 @@
-# CMS
-cfs-state-reporter=1.7.50-1
-cfs-trust=1.4.4-1
-cray-heartbeat=1.6.0-2.3_3.1__gb2e7d63.shasta
-cray-power-button=1.3.1-2.3_20220329162359__g0ddf9af
+# Packages common to all mediums.
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).
 
-# CSM
-cray-kubectl-hns-plugin=1.0.0-1
-cray-kubectl-kubelogin-plugin=1.25.1-1
-craycli=0.53.0-1
-csm-node-identity=1.0.18-1
-hpe-csm-scripts=0.0.34-1
-
-# CSM Testing Utils
-goss-servers=1.14.26-1
-hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
-hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
-
-# Base
 amsd=2.4.1-1571.4.sles15
 apparmor-profiles=2.13.6-150300.3.11.2
 arptables=0.0.4-8.39
@@ -128,6 +114,24 @@ vim=8.2.5038-150000.5.21.1
 vim-data=8.2.5038-150000.5.21.1
 zip=3.0-2.22
 zsh=5.6-7.5.1
+
+# CMS
+cfs-state-reporter=1.7.50-1
+cfs-trust=1.4.4-1
+cray-heartbeat=1.6.0-2.3_3.1__gb2e7d63.shasta
+cray-power-button=1.3.1-2.3_20220329162359__g0ddf9af
+
+# CSM
+cray-kubectl-hns-plugin=1.0.0-1
+cray-kubectl-kubelogin-plugin=1.25.1-1
+craycli=0.53.0-1
+csm-node-identity=1.0.18-1
+hpe-csm-scripts=0.0.34-1
+
+# CSM Testing Utils
+goss-servers=1.14.26-1
+hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
+hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 
 # Python3 RPM Packages
 # These support applications that do not install into virtualenvs, and that need airgap support.

--- a/packages/node-image-non-compute-common/google.packages
+++ b/packages/node-image-non-compute-common/google.packages
@@ -1,3 +1,7 @@
+# Google only packages
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).
 google-guest-agent=20220204.00-150000.1.26.1
 google-guest-configs=20220211.00-150000.1.19.1
 google-guest-oslogin=20220205.00-150000.1.27.1

--- a/packages/node-image-non-compute-common/metal.packages
+++ b/packages/node-image-non-compute-common/metal.packages
@@ -1,3 +1,7 @@
+# Metal only packages
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).
 biosdevname=0.7.3-5.3.1
 dracut-kiwi-live=9.24.17-150100.3.50.1
 dracut-metal-mdsquash=2.0.2-1

--- a/packages/node-image-storage-ceph/base.packages
+++ b/packages/node-image-storage-ceph/base.packages
@@ -1,4 +1,7 @@
-# Base
+# Packages common to all mediums.
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).
 cephadm=16.2.9.158+gd93952c7eea-lp153.3856.1
 jq=1.6-3.3.1
 libfmt7=7.1.3-bp153.1.17

--- a/packages/node-image-storage-ceph/google.packages
+++ b/packages/node-image-storage-ceph/google.packages
@@ -2,4 +2,3 @@
 # Format:
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
-nginx=1.19.8-3.6.1

--- a/packages/node-image-storage-ceph/metal.packages
+++ b/packages/node-image-storage-ceph/metal.packages
@@ -1,7 +1,9 @@
-# SES
-ses-release=7-64.1
+# Metal only packages
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).
 
-# Base
 golang-github-prometheus-node_exporter=1.3.0-150100.3.12.1
 haproxy=2.0.14-bp152.1.1
 keepalived=2.0.19-bp152.1.9
+ses-release=7-64.1


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

The current README is `.asc` but is formatted as Markdown, this fixes
that and then fills out some more details included how to add a package.

![Broken `.asc`](https://user-images.githubusercontent.com/7772179/177189976-974dd61b-405b-4092-929e-b14d4590539b.png)

![Fixed `.asc`](https://user-images.githubusercontent.com/7772179/177190032-27efd9b2-6b7c-4001-9b81-a1025b35ea61.png)

This also adds a PR template to replace the organizational wide template, which had several checkboxes that were not applicable to this repository.

Misc changes:
- Removal of `python-boto3` from `node-image-kubernetes`, this package is listed in `node-image-non-compute-common` and does not need to be listed in `node-image-kubernetes`. Listing it twice poses risk of an error, if someone updated `non-image-non-compute-common`'s `python-boto3` and didn't know it existed in `node-image-kubernetes`, then Kubernetes images would inadvertently downgrade the package.
- Added empty `google.packages` file to help circumvent the possibility that a maintainer will forget to update the `Jenkinsfile` if/when a `google.packages` file is necessary. This makes all the content folders the same, each containing a `base.packages`, `google.packages`, and `metal.packages` file.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes.

