### PR TITLE
CASMCLOUD-1208 update craycli to 0.56.0

### DIFF
--- a/packages/compute-node.packages
+++ b/packages/compute-node.packages
@@ -1,4 +1,4 @@
-craycli=0.50.0-1
+craycli=0.56.0-1
 cray-switchboard=1.2.3-1
 cray-uai-util=1.0.13-1
 cfs-state-reporter=1.7.50-1

--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -6,7 +6,7 @@
 # CSM Packages
 apache2=2.4.51-150200.3.45.1
 canu=1.6.5-1
-craycli=0.53.0-1
+craycli=0.56.0-1
 dnsmasq=2.86-150100.7.20.1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.34-1

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -125,7 +125,7 @@ cray-power-button=1.3.1-2.3_20220329162359__g0ddf9af
 # CSM
 cray-kubectl-hns-plugin=1.0.0-1
 cray-kubectl-kubelogin-plugin=1.25.1-1
-craycli=0.53.0-1
+craycli=0.56.0-1
 csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.34-1
 


### PR DESCRIPTION
## Summary and Scope

Update craycli to 0.56.0

This brings the BOS comands up to date (0.54.0), removes the obsolete `cray network` subcommand from the CLI (0.55.0), and makes some minor fixes to BOS (0.56.0).

These changes are backward compatible.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMCMS-8064
* Resolves [CASMCLOUD-1208](https://jira-pro.its.hpecorp.net:8443/browse/CASMCLOUD-1208) (0.55.0)
* Resolves CASMCMS-7876/CASMCMS-7848 (0.54.0)

## Testing

### Tested on:

  * Local development environment

### Test description:

The changes for 0.55.0 were tested by linting the code and running unit tests, then running the `cray network --help` command and verifying that there was no `network` sub-command supported.

The changes for 0.54.0 ad 0.56.0 (per the description provided by @rbak-hpe ) were tested as follows:

> Confirmed that the new fields were present in the api and that using them generated the correct json payload. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

There are no known risks with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable