### PR TITLE
CASMINST-4914 Need kernel-firmware for QLogic

### DIFF
--- a/packages/cray-pre-install-toolkit/metal.packages
+++ b/packages/cray-pre-install-toolkit/metal.packages
@@ -9,6 +9,7 @@ grub2-i386-pc=2.04-150300.22.20.2
 grub2-x86_64-efi=2.04-150300.22.20.2
 grub2=2.04-150300.22.20.2
 kernel-default=5.3.18-150300.59.76.1
+kernel-firmware=20210208-150300.4.10.1
 # When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
 kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
 kernel-source=5.3.18-150300.59.76.1

--- a/packages/node-image-non-compute-common/metal.packages
+++ b/packages/node-image-non-compute-common/metal.packages
@@ -10,6 +10,7 @@ grub2-i386-pc=2.04-150300.22.20.2
 grub2-x86_64-efi=2.04-150300.22.20.2
 grub2=2.04-150300.22.20.2
 kernel-default=5.3.18-150300.59.76.1
+kernel-firmware=20210208-150300.4.10.1
 # When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
 kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
 kernel-source=5.3.18-150300.59.76.1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-4914

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Adds `kernel-firmware`, allowing NIC adapters to be viewable on QLogic equipped systems.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
