### PR TITLE
CASMINST-3671: Pull in newer CSI version to pull in EX2500 cabinet support

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -15,7 +15,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.7-1
 
 # CSM METAL-team Packages
-cray-site-init=1.20.2-1
+cray-site-init=1.21.0-1
 ilorest=3.5.1-1
 metal-basecamp=1.2.0-1
 metal-ipxe=2.2.7-1


### PR DESCRIPTION
### Summary and Scope
- Fixes: CASMINST-3671 and CASMINST-3787

#### Issue Type
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Pull in newer CSI version to pull in EX2500 cabinet support. For additional detail see: https://github.com/Cray-HPE/cray-site-init/pulls?q=is%3Apr+is%3Aclosed


### Prerequisites
- [] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
See https://github.com/Cray-HPE/cray-site-init/pulls?q=is%3Apr+is%3Aclosed