### PR TITLE
CASMCMS-8073: cmstools stop using deprecated HSMv1 API

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -3,7 +3,7 @@
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
 
-cray-cmstools-crayctldeploy=1.3.3-1
+cray-cmstools-crayctldeploy=1.4.0-1
 ipvsadm=1.29-4.3.1
 kubeadm=1.21.12-0
 kubelet=1.21.12-0


### PR DESCRIPTION
## Summary and Scope

Move to updated cmstools that stops using the deprecated v1 HSM API and uses v2 instead.

## Risks and Mitigations

It will be broken without this change, since v1 is gone in csm v1.3.

## Pull Request Checklist

- [X] Target branch correct
