### PR TITLE
CASMPET-5737: Goss Test for Nexus Space On Upgrade

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -129,7 +129,7 @@ csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.36-1
 
 # CSM Testing Utils
-goss-servers=1.14.30-1
+goss-servers=1.14.31-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMPET-5737](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5737)

#### Issue Type

- Docs Pull Request

This adds in a goss test for the space needed for Nexus in the 1.3 upgrade

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
Tested on mug with a pass with current required size.
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
There is now risk in a failing test. But this will prevent a failed upgrade due to Nexus filling up.
