### PR TITLE
CASMINST-4932: Pull in newer CSI to use HSM V2 API.

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -15,7 +15,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.7-1
 
 # CSM METAL-team Packages
-cray-site-init=1.21.0-1
+cray-site-init=1.22.0-1
 ilorest=3.5.1-1
 metal-basecamp=1.2.0-1
 metal-ipxe=2.2.8-1


### PR DESCRIPTION
### Summary and Scope
- Fixes: CASMINST-4932

#### Issue Type
- Bugfix Pull Request

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

This change was tested on Surtur. For testing see:  https://github.com/Cray-HPE/cray-site-init/pull/209

### Risks and Mitigations
Low risk. The HSM v1 API will be removed in an upcoming CSM release.  
