### PR TITLE
MTL-1853 Google Has Mismatching Kernel

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -17,6 +17,12 @@ manifestgen=1.3.7-1
 # CSM METAL-team Packages
 cray-site-init=1.22.0-1
 ilorest=3.5.1-1
+kernel-default=5.3.18-150300.59.76.1
+kernel-firmware=20210208-150300.4.10.1
+# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
+kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
+kernel-source=5.3.18-150300.59.76.1
+kernel-syms=5.3.18-150300.59.76.1
 metal-basecamp=1.2.0-1
 metal-ipxe=2.2.8-1
 metal-net-scripts=0.0.2-1

--- a/packages/cray-pre-install-toolkit/metal.packages
+++ b/packages/cray-pre-install-toolkit/metal.packages
@@ -8,12 +8,6 @@ grub2-branding-SLE=15-33.3.1
 grub2-i386-pc=2.04-150300.22.20.2
 grub2-x86_64-efi=2.04-150300.22.20.2
 grub2=2.04-150300.22.20.2
-kernel-default=5.3.18-150300.59.76.1
-kernel-firmware=20210208-150300.4.10.1
-# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
-kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
-kernel-source=5.3.18-150300.59.76.1
-kernel-syms=5.3.18-150300.59.76.1
 ledmon=0.94-1.59
 # DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"
 mft=4.20.0-34

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -131,6 +131,14 @@ craycli=0.57.0-1
 csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.36-1
 
+# CSM Metal
+kernel-default=5.3.18-150300.59.76.1
+kernel-firmware=20210208-150300.4.10.1
+# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
+kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
+kernel-source=5.3.18-150300.59.76.1
+kernel-syms=5.3.18-150300.59.76.1
+
 # CSM Testing Utils
 goss-servers=1.14.31-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77

--- a/packages/node-image-non-compute-common/metal.packages
+++ b/packages/node-image-non-compute-common/metal.packages
@@ -9,12 +9,6 @@ grub2-branding-SLE=15-33.3.1
 grub2-i386-pc=2.04-150300.22.20.2
 grub2-x86_64-efi=2.04-150300.22.20.2
 grub2=2.04-150300.22.20.2
-kernel-default=5.3.18-150300.59.76.1
-kernel-firmware=20210208-150300.4.10.1
-# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
-kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
-kernel-source=5.3.18-150300.59.76.1
-kernel-syms=5.3.18-150300.59.76.1
 ledmon=0.94-1.59
 mdadm=4.1-150300.24.15.1
 # DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1853

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Google builds do not invoke `metal.packages`, and thus are susceptible to having a newer kernel than metal. We want to lock the kernel overall, so this moves the kernel packages into `base.packages` to do just that.

**This does not fix the multiple kernel issue in MTL-1853**, this resolves a tangental issue discovered while fixing MTL-1853.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
