### PR TITLE
CASMINST-4940 Upgrade command changes + dependency updates

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -15,7 +15,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.7-1
 
 # CSM METAL-team Packages
-cray-site-init=1.22.0-1
+cray-site-init=1.23.0-1
 ilorest=3.5.1-1
 kernel-default=5.3.18-150300.59.76.1
 kernel-firmware=20210208-150300.4.10.1

--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -15,7 +15,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.7-1
 
 # CSM METAL-team Packages
-cray-site-init=1.23.0-1
+cray-site-init=1.23.2-1
 ilorest=3.5.1-1
 kernel-default=5.3.18-150300.59.76.1
 kernel-firmware=20210208-150300.4.10.1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-4940

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
See: https://github.com/Cray-HPE/cray-site-init/pull/204

This also brings in some dependency updates from dependabot:
- https://github.com/Cray-HPE/cray-site-init/pull/213
- https://github.com/Cray-HPE/cray-site-init/pull/214
- https://github.com/Cray-HPE/cray-site-init/pull/215
- https://github.com/Cray-HPE/cray-site-init/pull/216
- https://github.com/Cray-HPE/cray-site-init/pull/217
- https://github.com/Cray-HPE/cray-site-init/pull/218
- https://github.com/Cray-HPE/cray-site-init/pull/219
- https://github.com/Cray-HPE/cray-site-init/pull/220
- https://github.com/Cray-HPE/cray-site-init/pull/221


### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
