### PR TITLE
Update craycli rpm version to 0.58.0 to remove HSM v1 APIs

### DIFF
--- a/packages/compute-node.packages
+++ b/packages/compute-node.packages
@@ -1,4 +1,4 @@
-craycli=0.57.0-1
+craycli=0.58.0-1
 cray-switchboard=1.2.3-1
 cray-uai-util=1.0.13-1
 cfs-state-reporter=1.7.50-1

--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -6,7 +6,7 @@
 # CSM Packages
 apache2=2.4.51-150200.3.48.1
 canu=1.6.5-1
-craycli=0.57.0-1
+craycli=0.58.0-1
 dnsmasq=2.86-150100.7.20.1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.36-1

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -127,7 +127,7 @@ cray-power-button=1.3.1-2.3_20220329162359__g0ddf9af
 # CSM
 cray-kubectl-hns-plugin=1.0.0-1
 cray-kubectl-kubelogin-plugin=1.25.1-1
-craycli=0.57.0-1
+craycli=0.58.0-1
 csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.36-1
 


### PR DESCRIPTION
### Summary and Scope

This removes the deprecated HSM v1 APIs from craycli

- Fixes: [CASMHMS-5628](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5628)

#### Issue Type

- RFE Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
None
