### PR TITLE
CASMTRIAGE-3784: Use 1.3.2 platform utils

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -9,7 +9,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 loftsman=1.2.0-1
 manifestgen=1.3.7-1
-platform-utils=1.3.1-1
+platform-utils=1.3.2-1
 
 # COS
 cray-cps-utils=0.11.0-2.3_20220329162848__gfb2fe6a


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-3784
- Requires: https://github.com/Cray-HPE/utils/pull/54
- Relates to: CASMINST-5051

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

Pulls in fixes for the spire token fix script where ssh may fail in certain conditions causing the script not to update the spire storage token and files.
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x ] I tested this on internal system (if yes, please include results or a description of the test) Tyr, Drax, Fanta, Mug
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
As it stands if the cloud init join script fails, and this script is run, depending on what is in ~/.ssh and if the node is in authorized_hosts the fix script won't fix anything.
