### PR TITLE
CASMCMS-8068: Allow user to specify image used in barebones test

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -3,7 +3,7 @@
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
 
-cray-cmstools-crayctldeploy=1.5.0-1
+cray-cmstools-crayctldeploy=1.6.0-beta.1
 ipvsadm=1.29-4.3.1
 kubeadm=1.21.12-0
 kubelet=1.21.12-0


### PR DESCRIPTION
## Summary and Scope

- Fixes: [CASMCMS-8068](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8068)
- Source PR: https://github.com/Cray-HPE/cms-tools/pull/44
- csm manifest PR: https://github.com/Cray-HPE/csm/pull/1072

### Issue Type

- RFE Pull Request

Adds the option for users to specify the image used in the barebones boot test. In some cases, the default of picking the first image with "barebones" in its name does not work. This allows a way to handle that, if it occurs.

## Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

### Testing

I tested this on rocket, both with and without an ID being specified, to make sure that both cases still work correctly. I also tested to make sure it behaved appropriately if an invalid ID is specified.

## Risks and Mitigations

Low risk -- the default behavior of the test is not changed. This only adds a new option. And this new option allows some people to be able to run the test who otherwise would not be able to.
