### PR TITLE
CASMUSER-3050: Add hmnlb and hmn blackhole routes for UAI

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -15,7 +15,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.7-1
 
 # CSM METAL-team Packages
-cray-site-init=1.23.2-1
+cray-site-init=1.24.0-1
 ilorest=3.5.1-1
 kernel-default=5.3.18-150300.59.76.1
 kernel-firmware=20210208-150300.4.10.1


### PR DESCRIPTION
#### Summary and Scope

- Fixes CASMUSER-3028
- Fixes CASMUSER-3050

##### Issue Type

- Bugfix Pull Request

CSI adds "routes" for the UAI net-attach-definition customizations to invalid IPs as a blackhole for traffic that should not go out the weave net over the default route.

Add two new routes for HMN and HMNLB.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) 

I tested this with the net-attach-def set to ipvlan/hsn and macvlan/nmn. I pulled the new routes from a locally built `csi` using hermod seed files. The new routes are shown here:
```
    routes:
    - dst: 10.92.100.0/24        <-- new HMNLB
      gw: 10.252.2.6
    - dst: 10.254.0.0/17        <-- new HMN
      gw: 10.252.2.6
    - dst: 10.101.3.0/25
      gw: 10.252.0.1
    - dst: 10.94.100.0/24
      gw: 10.252.2.6
    - dst: 10.106.0.0/17
      gw: 10.252.0.1
```

With a modified net-attach-def including these routes, I could not hit IPs on those networks as intended. This was done over ipvlan/hsn and macvlan/nmn configurations on hermod.
 
#### Idempotency
 
Ran `csi config init` on hermod's seed files 
 
#### Risks and Mitigations
 
Risk that somehow the routes aren't configured right. Result would be UAIs or WLM pods stuck in ContainerCreating. Mitigation would be to run `kubectl edit -n user net-attach-def` and remove the new routes.
