### PR TITLE
CASMINST-5124/CASMINST-5129: Fix NCN image build issue, Fix typo in ncn-healthcheck-master script

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -141,7 +141,7 @@ kernel-source=5.3.18-150300.59.76.1
 kernel-syms=5.3.18-150300.59.76.1
 
 # CSM Testing Utils
-goss-servers=1.14.31-1
+goss-servers=1.14.34-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
### Summary and Scope

See source PRs for details:
https://github.com/Cray-HPE/csm-testing/pull/348
https://github.com/Cray-HPE/csm-testing/pull/347

- Fixes: [CASMINST-5124](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5124)
- Fixes: [CASMINST-5129](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5129)

#### Issue Type

- Bugfix Pull Request

Fixed a build issue and a test issue.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

### Risks and Mitigations

Without these changes, one of the goss test scripts does not work, and the goss-servers RPM cannot be updated to a new version in the NCN images.
 