### PR TITLE
MTL-1867 Pin libelf1

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -48,6 +48,7 @@ fonts-config=20200609+git0.42e2b1b-4.7.1
 git-core=2.35.3-150300.10.12.1
 libctf0=2.37-150100.7.37.1
 libbd_mdraid2=2.22-1.36
+libelf1=0.168-4.5.3
 ipmitool=1.8.18+git20200204.7ccea28-3.3.1
 iproute2-bash-completion=5.3-5.5.1
 iproute2=5.3-5.5.1

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -49,6 +49,7 @@ less=530-3.3.2
 libbd_mdraid2=2.22-1.36
 libcanberra-gtk0=0.30-3.2.3
 libecpg6=14.3-150200.5.12.2
+libelf1=0.168-4.5.3
 libfreebl3-hmac=3.68.3-150000.3.67.1
 libfreebl3=3.68.3-150000.3.67.1
 liblldp_clif1=1.1+44.0f781b4162d3-3.3.1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1867

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Base images are building with too new of a libelf1 library that conflicts with our pinned kernel version, this is causing full NCN builds (builds of the base image) to fail.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
