### PR TITLE
CASMPET-5531: BREAK/FIX: etcd cluster restore needs to verify that et…

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -9,7 +9,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 loftsman=1.2.0-1
 manifestgen=1.3.7-1
-platform-utils=1.3.2-1
+platform-utils=1.3.4-1
 
 # COS
 cray-cps-utils=0.11.0-2.3_20220329162848__gfb2fe6a


### PR DESCRIPTION
Update to kubernets packages to pull in platform-utils=1.3.4-1
This pulls in changes for:
    CASMPET-5531
### Summary and Scope

Master - CASMPET-5531: BREAK/FIX: etcd cluster restore needs to verify that etcd-client gets created.

At times during an etcd cluster restore, the etcd operator fails to create the etcd-client service.
With this change, early detection of this failure now automatically repeats up to four attempts of the restore process before notifying the user of the failed restore.
