### PR TITLE
MTL-1863 Invoke `mkinitrd` on update/install

### DIFF
--- a/packages/node-image-kubernetes/metal.packages
+++ b/packages/node-image-kubernetes/metal.packages
@@ -3,7 +3,7 @@
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
 
-dracut-metal-dmk8s=2.0.3-1
-dracut-metal-luksetcd=2.0.3-1
+dracut-metal-dmk8s=2.0.4-1
+dracut-metal-luksetcd=2.0.4-1
 haproxy=2.0.14-bp152.1.1
 keepalived=2.0.19-bp152.1.9

--- a/packages/node-image-non-compute-common/metal.packages
+++ b/packages/node-image-non-compute-common/metal.packages
@@ -4,7 +4,7 @@
 # The version is the same version reported by the OS package manager (e.g. zypper).
 biosdevname=0.7.3-5.3.1
 dracut-kiwi-live=9.24.17-150100.3.50.1
-dracut-metal-mdsquash=2.1.1-1
+dracut-metal-mdsquash=2.1.2-1
 grub2-branding-SLE=15-33.3.1
 grub2-i386-pc=2.04-150300.22.20.2
 grub2-x86_64-efi=2.04-150300.22.20.2


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1863

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
On install or update of the dracut RPMs the initrd and kdump initrd will be updated. This was tested and worked, the kdump initrd is only updated if kdump is installed.

See:
- https://github.com/Cray-HPE/dracut-metal-mdsquash/pull/49
- https://github.com/Cray-HPE/dracut-metal-luksetcd/pull/39
- https://github.com/Cray-HPE/dracut-metal-dmk8s/pull/29

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
