### PR TITLE
CASMINST-5161: Reduce excessive Goss script output

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -147,7 +147,7 @@ kernel-source=5.3.18-150300.59.76.1
 kernel-syms=5.3.18-150300.59.76.1
 
 # CSM Testing Utils
-goss-servers=1.14.39-1
+goss-servers=1.14.40-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMINST-5161](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5161)

csm repo PR: https://github.com/Cray-HPE/csm/pull/1125

#### Issue Type

- RFE Pull Request

Modify automated Goss scripts so that they only print failure information to screen, and successes to a log file.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

See source PR for testing details: https://github.com/Cray-HPE/csm-testing/pull/355

### Risks and Mitigations

Medium risk, but big payoff in usability. 
