### PR TITLE
MTL-1878 Make teams more clear

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -3,10 +3,12 @@
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
 
-cray-cmstools-crayctldeploy=1.6.0-beta.1
 ipvsadm=1.29-4.3.1
 kubeadm=1.21.12-0
 kubelet=1.21.12-0
+
+# CSM
+cray-cmstools-crayctldeploy=1.6.0-beta.1
 loftsman=1.2.0-1
 manifestgen=1.3.7-1
 platform-utils=1.3.5-1
@@ -18,8 +20,8 @@ cray-orca=0.9.1-2.3_20220329135308__g8f2d4d6
 # DVS
 insserv-compat=0.1-4.6.1
 
-# SDU
-cray-sdu-rda=2.0.1-shasta_20220712130245_fe07e86
-
 # SAT
 cray-prodmgr=1.1.2-20220104153307_2374f1f
+
+# SDU
+cray-sdu-rda=2.0.1-shasta_20220712130245_fe07e86

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -109,7 +109,6 @@ s3fs=1.91-150000.3.9.1
 screen=4.6.2-5.3.1
 smartmontools=7.2-150300.8.5.1
 socat=1.7.3.2-4.10
-spire-agent=0.12.2-2.3_20220420125806__gf6cdaa8
 squid=4.17-5.29.1
 strace=5.3-1.44
 sudo=1.9.5p2-150300.3.6.1
@@ -130,26 +129,27 @@ zsh=5.6-7.5.1
 # CMS
 cfs-state-reporter=1.7.50-1
 cfs-trust=1.4.4-1
+
+# COS
 cray-heartbeat=1.6.0-2.3_3.2__gb2e7d63.shasta
 cray-power-button=1.3.1-2.3_20220329162359__g0ddf9af
+spire-agent=0.12.2-2.3_20220420125806__gf6cdaa8
 
 # CSM
 cray-kubectl-hns-plugin=1.0.0-1
 cray-kubectl-kubelogin-plugin=1.25.1-1
 craycli=0.58.0-1
 csm-node-identity=1.0.18-1
+goss-servers=1.14.40-1
+hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.38-1
+hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 
-# CSM Metal
+# Metal
 kernel-default=5.3.18-150300.59.76.1
 kernel-firmware=20210208-150300.4.10.1
 kernel-source=5.3.18-150300.59.76.1
 kernel-syms=5.3.18-150300.59.76.1
-
-# CSM Testing Utils
-goss-servers=1.14.40-1
-hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
-hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 
 # Python3 RPM Packages
 # These support applications that do not install into virtualenvs, and that need airgap support.

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -1,8 +1,13 @@
-https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.3/sle15_sp3_ncn/                         cray-cos-sle-15sp3-SHASTA-OS-cos                  --no-gpgcheck -p 89                   cray/cos/sle-15sp3-ncn
-
+# CSM / CLOUD / PET / MTL / NET
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/                                        cray-algol60-csm-rpms-stable-sle-15sp4            --no-gpgcheck -p 88                   cray/csm/sle-15sp4
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/                                        cray-algol60-csm-rpms-stable-sle-15sp3            --no-gpgcheck -p 88                   cray/csm/sle-15sp3
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/                                        cray-algol60-csm-rpms-stable-sle-15sp2            --no-gpgcheck -p 89                   cray/csm/sle-15sp2
 
+# COS
+https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.3/sle15_sp3_ncn/                         cray-cos-sle-15sp3-SHASTA-OS-cos                  --no-gpgcheck -p 89                   cray/cos/sle-15sp3-ncn
+
+# SAT
 https://arti.dev.cray.com/artifactory/sat-rpm-master-local/dev/master/sle15_sp2_ncn/                              cray-sat-sle-15sp2-x86_64-master                  --no-gpgcheck -p 89                   cray/sat/sle-15sp2/x86_64
 
+# SDU
 https://arti.dev.cray.com/artifactory/sdu-rpm-stable-local/release/img_oci-shasta-2.0/sle15_sp3_ncn/              sdu-rpm-stable-local                              --no-gpgcheck -p 89                   sdu-rpm-stable-local/release/2.0/sle15_sp3_ncn/


### PR DESCRIPTION
Some RPMs for COS were floating in the general list, additionally this organizes the `cray.repos` file to put the removable repos last.