### PR TITLE
CASMNET-1757: CANU bugfixes including UAN VLAN as None

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -5,7 +5,7 @@
 
 # CSM Packages
 apache2=2.4.51-150200.3.48.1
-canu=1.6.9-1
+canu=1.6.13-1
 craycli=0.58.0-1
 dnsmasq=2.86-150100.7.20.1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77


### PR DESCRIPTION
### Summary and Scope

Overview

    BUGFIX: Fix UAN configuration templates producing None VLAN when CHN is enabled.
    BUGFIX: Enable 1.3 configuration templates in the pyinstaller binary.

Details

    Update docs generated from code.
    Change exception-handling in canu validate shcd and from network_modeling.
    Provide better next steps from errors reported while validating SHCDs.
    Add canu test to ping Kea DHCP.
    Update to release process doc


- Fixes: CASMNET-1757

#### Issue Type

- Bugfix [Release 1.6.13](https://github.com/Cray-HPE/canu/pull/196)

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
