### PR TITLE
CRAYSAT-1509: Add cray-sat-podman version 2.0.0 to NCN image

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -22,6 +22,7 @@ insserv-compat=0.1-4.6.1
 
 # SAT
 cray-prodmgr=1.1.2-20220104153307_2374f1f
+cray-sat-podman=2.0.0
 
 # SDU
 cray-sdu-rda=2.0.1-shasta_20220712130245_fe07e86

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -7,6 +7,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/      
 https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.3/sle15_sp3_ncn/                         cray-cos-sle-15sp3-SHASTA-OS-cos                  --no-gpgcheck -p 89                   cray/cos/sle-15sp3-ncn
 
 # SAT
+https://artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3/                                        cray-algol60-sat-rpms-stable-sle-15sp3            --no-gpgcheck -p 88                   cray/sat/sle-15sp3
 https://arti.dev.cray.com/artifactory/sat-rpm-master-local/dev/master/sle15_sp2_ncn/                              cray-sat-sle-15sp2-x86_64-master                  --no-gpgcheck -p 89                   cray/sat/sle-15sp2/x86_64
 
 # SDU


### PR DESCRIPTION
* This commit adds cray-sat-podman into the NCN image.
* Add sat-rpms artifactory repository

Test Description:
After building the 2.0.0 version of cray-sat-podman, I built the
kubernetes image and verified the expected RPM was installed.

### Summary and Scope

- Fixes: [CRAYSAT-1509](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1508), [CRAYSAT-1508](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1508)
- Relates to: [CSM PR #1137](https://github.com/Cray-HPE/csm/pull/1137)