### PR TITLE
CASMINST-5209 update pit-init

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -24,7 +24,7 @@ kernel-syms=5.3.18-150300.59.76.1
 metal-basecamp=1.2.0-1
 metal-ipxe=2.2.8-1
 metal-net-scripts=0.0.2-1
-pit-init=1.2.32-1
+pit-init=1.2.33-1
 pit-nexus=1.1.5-1
 
 # SUSE Packages


### PR DESCRIPTION
### Summary and Scope

Updates pit-init to include new get-sqfs.sh script for that progress bar/eta goodness.

- Fixes: CASMINST-5209
- Requires:
- Relates to:

#### Issue Type

- Bugfix Pull Request


### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x ] I tested this on internal system redbull
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
Not very risky, and if it isn't pulled in get-sqfs.sh just doesn't have progress bars or an eta.
