### PR TITLE
Revert "CRAYSAT-1509: Add cray-sat-podman version 2.0.0 to NCN image"

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -22,6 +22,7 @@ insserv-compat=0.1-4.6.1
 
 # SAT
 cray-prodmgr=1.1.2-20220104153307_2374f1f
+cray-sat-podman=2.0.0
 
 # SDU
 cray-sdu-rda=2.0.1-shasta_20220712130245_fe07e86

--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -22,7 +22,7 @@ insserv-compat=0.1-4.6.1
 
 # SAT
 cray-prodmgr=1.1.2-20220104153307_2374f1f
-cray-sat-podman=2.0.0
+cray-sat-podman=2.0.0-1
 
 # SDU
 cray-sdu-rda=2.0.1-shasta_20220712130245_fe07e86

--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -22,7 +22,6 @@ insserv-compat=0.1-4.6.1
 
 # SAT
 cray-prodmgr=1.1.2-20220104153307_2374f1f
-cray-sat-podman=2.0.0
 
 # SDU
 cray-sdu-rda=2.0.1-shasta_20220712130245_fe07e86

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -7,6 +7,7 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/      
 https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.3/sle15_sp3_ncn/                         cray-cos-sle-15sp3-SHASTA-OS-cos                  --no-gpgcheck -p 89                   cray/cos/sle-15sp3-ncn
 
 # SAT
+https://artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3/                                        cray-algol60-sat-rpms-stable-sle-15sp3            --no-gpgcheck -p 88                   cray/sat/sle-15sp3
 https://arti.dev.cray.com/artifactory/sat-rpm-master-local/dev/master/sle15_sp2_ncn/                              cray-sat-sle-15sp2-x86_64-master                  --no-gpgcheck -p 89                   cray/sat/sle-15sp2/x86_64
 
 # SDU

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -7,7 +7,6 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/      
 https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.3/sle15_sp3_ncn/                         cray-cos-sle-15sp3-SHASTA-OS-cos                  --no-gpgcheck -p 89                   cray/cos/sle-15sp3-ncn
 
 # SAT
-https://artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3/                                        cray-algol60-sat-rpms-stable-sle-15sp3            --no-gpgcheck -p 88                   cray/sat/sle-15sp3
 https://arti.dev.cray.com/artifactory/sat-rpm-master-local/dev/master/sle15_sp2_ncn/                              cray-sat-sle-15sp2-x86_64-master                  --no-gpgcheck -p 89                   cray/sat/sle-15sp2/x86_64
 
 # SDU


### PR DESCRIPTION
Reverts Cray-HPE/csm-rpms#542 and re-applies it with the proper version.