### PR TITLE
Update to cray-sdu-rda-2.1.0 in base.packages for CSM 1.3, Papaya RC1 8/12/22

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -25,4 +25,4 @@ cray-prodmgr=1.1.2-20220104153307_2374f1f
 cray-sat-podman=2.0.0-1
 
 # SDU
-cray-sdu-rda=2.0.1-shasta_20220712130245_fe07e86
+cray-sdu-rda=2.1.0-shasta_20220810231129_03043fd

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -11,4 +11,4 @@ https://artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3/      
 https://arti.dev.cray.com/artifactory/sat-rpm-master-local/dev/master/sle15_sp2_ncn/                              cray-sat-sle-15sp2-x86_64-master                  --no-gpgcheck -p 89                   cray/sat/sle-15sp2/x86_64
 
 # SDU
-https://arti.dev.cray.com/artifactory/sdu-rpm-stable-local/release/img_oci-shasta-2.0/sle15_sp3_ncn/              sdu-rpm-stable-local                              --no-gpgcheck -p 89                   sdu-rpm-stable-local/release/2.0/sle15_sp3_ncn/
+https://arti.dev.cray.com/artifactory/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn/              sdu-rpm-stable-local                              --no-gpgcheck -p 89                   sdu-rpm-stable-local/release/2.1/sle15_sp3_ncn/


### PR DESCRIPTION
### Summary and Scope

- Fixes: HPCCHT3-3379 "cray-sdu-rda-2.1.0-shasta release" 

#### Issue Type
- RFE Pull Request

This change is to update the version of cray-sdu-rda for the Papaya RC1 8/12 release in the base NCN image. This change needs to be in the CSM 1.3 release branch, please.

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system. Testing [here](https://github.hpe.com/hpe/hpc-ch-sdu-tarfile-shasta/tree/cray-sdu-rda-2.1.0-shasta/testing/HPCCHT3-3379_2.1.0_release)
- [ ] I tested this on a vshasta system

### Risks and Mitigations
 
Low risk installation of a benign RPM that doesn't do anything other than place files in the base OS. This RPM becomes functional post recipe installation.