### PR TITLE
CASMCMS-8090: Update craycli for latest BOS v2 changes

### DIFF
--- a/packages/compute-node.packages
+++ b/packages/compute-node.packages
@@ -1,4 +1,4 @@
-craycli=0.59.0-1
+craycli=0.60.0-1
 cray-switchboard=1.2.3-1
 cray-uai-util=1.0.13-1
 cfs-state-reporter=1.9.0-1

--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -6,7 +6,7 @@
 # CSM Packages
 apache2=2.4.51-150200.3.48.1
 canu=1.6.13-1
-craycli=0.59.0-1
+craycli=0.60.0-1
 dnsmasq=2.86-150100.7.20.1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.38-1

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -138,7 +138,7 @@ spire-agent=0.12.2-2.3_20220420125806__gf6cdaa8
 # CSM
 cray-kubectl-hns-plugin=1.0.0-1
 cray-kubectl-kubelogin-plugin=1.25.1-1
-craycli=0.59.0-1
+craycli=0.60.0-1
 csm-node-identity=1.0.18-1
 goss-servers=1.14.42-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77


### PR DESCRIPTION
### Summary and Scope

This updates the cli to match the final api for BOS v2, and switches the cli to start hitting the v2 endpoint if no version is specified.


#### Issue Type

- RFE Pull Request

This updates the cli to match the final api for BOS v2

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)  Not required.
- [X] I tested this on internal system (if yes, please include results or a description of the test)  Verified the commands that the cli calls
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
None
