### PR TITLE
CASMINST-5240: Disable cmsdev testing of BOS CLI without explicitly specifying the version

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.6.0-beta.1
+cray-cmstools-crayctldeploy=1.6.1-1
 loftsman=1.2.0-1
 manifestgen=1.3.7-1
 platform-utils=1.3.5-1


### PR DESCRIPTION
### Summary and Scope

Fixes cmsdev test false failure. See source PR for details:
https://github.com/Cray-HPE/cms-tools/pull/48

- Fixes: [CASMINST-5240](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5240)
- Relates to: [CASMCMS-8087](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8087)
- csm manifest PR: https://github.com/Cray-HPE/csm/pull/1164

#### Issue Type

- Bugfix Pull Request

Fixes cmsdev test false failure. See source PR for details:
https://github.com/Cray-HPE/cms-tools/pull/48

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
Very low risk -- two subtests are removed. No changes to anything else.