### PR TITLE
CASMINST-5240: Disable cmsdev testing of BOS CLI without explicitly specifying the version (#555)

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.6.0-beta.1
+cray-cmstools-crayctldeploy=1.6.1-1
 loftsman=1.2.0-1
 manifestgen=1.3.7-1
 platform-utils=1.3.5-1


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm-rpms/pull/555