### PR TITLE
Fix 1.2 pinning of kernel

### DIFF
--- a/packages/node-image-non-compute-common/metal.packages
+++ b/packages/node-image-non-compute-common/metal.packages
@@ -6,6 +6,7 @@ grub2-x86_64-efi=2.04-150300.22.12.2
 mdadm=4.1-24.6.1
 dracut-kiwi-live=9.24.16-3.44.1
 dracut-metal-mdsquash=1.9.3-1
+kernel-default=5.3.18-150300.59.43.1
 kernel-source=5.3.18-150300.59.43.1
 kernel-syms=5.3.18-150300.59.43.1
 kernel-mft-mlnx-kmp-default=4.17.0_k5.3.18_57-1.sles15sp3


### PR DESCRIPTION
Kernel isn't pinned, making rebuilds of 1.2 NCNs pull in newer kernels.