### PR TITLE
CRAYSAT-1476: Update prodmgr to stable version

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -18,7 +18,7 @@ cray-orca=0.9.1-2.3_20220329135308__g8f2d4d6
 insserv-compat=0.1-4.6.1
 
 # SAT
-cray-prodmgr=1.1.2-20220104153307_2374f1f
+cray-prodmgr=1.1.6-1
 cray-sat-podman=2.0.0-1
 
 # SDU

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -8,7 +8,6 @@ https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.3/sle15
 
 # SAT
 https://artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3/                                        cray-algol60-sat-rpms-stable-sle-15sp3            --no-gpgcheck -p 88                   cray/sat/sle-15sp3
-https://arti.dev.cray.com/artifactory/sat-rpm-master-local/dev/master/sle15_sp2_ncn/                              cray-sat-sle-15sp2-x86_64-master                  --no-gpgcheck -p 89                   cray/sat/sle-15sp2/x86_64
 
 # SDU
 https://arti.dev.cray.com/artifactory/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn/              sdu-rpm-stable-local                              --no-gpgcheck -p 89                   sdu-rpm-stable-local/release/2.1/sle15_sp3_ncn/


### PR DESCRIPTION


Test Description:


### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CRAYSAT-1476

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

This change updates the version of the prodmgr RPM to the new stable
release. The old arti.dev.cray.com repo was also removed.

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

Build kubernetes node image and confirm the correct RPM versions are
present.

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
This change updates `prodmgr`. If including the new version introduces errors, the new version can be rolled back.