### PR TITLE
Support Virtualization

### DIFF
--- a/packages/node-image-kubernetes/metal.packages
+++ b/packages/node-image-kubernetes/metal.packages
@@ -2,7 +2,6 @@
 # Format:
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
-
 dracut-metal-dmk8s=2.0.4-1
 dracut-metal-luksetcd=2.0.4-1
 haproxy=2.0.14-bp152.1.1

--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -2,7 +2,6 @@
 # Format:
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
-
 amsd=2.4.1-1571.4.sles15
 apparmor-profiles=2.13.6-150300.3.11.2
 arptables=0.0.4-8.39
@@ -10,6 +9,7 @@ at=3.1.20-11.3
 aws-cli=1.20.7-30.3.1
 bc=1.07.1-11.37
 bind-utils=9.16.6-150300.22.16.1
+biosdevname=0.7.3-5.3.1
 bsdtar=3.4.2-150200.4.6.1
 ceph-common>=16.2.9
 cloud-init-config-suse=21.4-1
@@ -22,10 +22,11 @@ cryptsetup=2.3.7-150300.3.5.1
 dkms=2.3-bp153.1.17
 dnsmasq=2.86-150100.7.20.1
 dosfstools=4.1-3.6.1
+dracut-kiwi-live=9.24.17-150100.3.50.1
 dump=0.4b46-1.31
 ebtables=2.0.11-1.1
-elfutils=0.168-4.5.3
 elfutils-lang=0.168-4.5.3
+elfutils=0.168-4.5.3
 emacs=25.3-3.9.2
 ethtool=5.9-1.31
 expect=5.45.4-3.3.1
@@ -37,6 +38,10 @@ git-core=2.35.3-150300.10.12.1
 gnuplot=5.2.2-3.9.2
 gperftools=2.5-4.12
 gptfdisk=1.0.1-2.11
+grub2-branding-SLE=15-33.3.1
+grub2-i386-pc=2.04-150300.22.20.2
+grub2-x86_64-efi=2.04-150300.22.20.2
+grub2=2.04-150300.22.20.2
 hdparm=9.52-1.22
 hplip=3.21.10-4.3.1
 ipmitool=1.8.18+git20200204.7ccea28-3.3.1
@@ -54,8 +59,8 @@ libcanberra-gtk0=0.30-3.2.3
 libdw1=0.168-4.5.3
 libebl-plugins=0.168-4.5.3
 libecpg6=14.3-150200.5.12.2
-libelf1=0.168-4.5.3
 libelf-devel=0.168-4.5.3
+libelf1=0.168-4.5.3
 libfreebl3-hmac=3.68.3-150000.3.67.1
 libfreebl3=3.68.3-150000.3.67.1
 liblldp_clif1=1.1+44.0f781b4162d3-3.3.1
@@ -71,6 +76,7 @@ lvm2=2.03.05-8.42.1
 man=2.7.6-6.22
 mariadb-tools=10.5.16-150300.3.18.1
 mariadb=10.5.16-150300.3.18.1
+mdadm=4.1-150300.24.15.1
 minicom=2.7.1-1.19
 mlocate=0.26-150100.7.3.2
 nmap=7.70-3.12.1
@@ -115,6 +121,8 @@ sudo=1.9.5p2-150300.3.6.1
 sysstat=12.0.2-3.33.1
 systemtap=4.2-3.3.1
 tcpdump=4.9.2-3.18.1
+tpm2.0-abrmd=2.3.3-3.3.1
+tpm2.0-tools=4.3.0-4.3.1
 unixODBC=2.3.9-8.3.2
 unzip=6.00-4.8.13
 usbutils=014-3.3.1
@@ -148,8 +156,12 @@ hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 # Metal
 kernel-default=5.3.18-150300.59.43.1
 kernel-firmware=20210208-150300.4.10.1
+kernel-macros=5.3.18-150300.59.43.1
 kernel-source=5.3.18-150300.59.43.1
 kernel-syms=5.3.18-150300.59.43.1
+# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
+kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
+mft=4.20.0-34
 
 # Python3 RPM Packages
 # These support applications that do not install into virtualenvs, and that need airgap support.

--- a/packages/node-image-non-compute-common/metal.packages
+++ b/packages/node-image-non-compute-common/metal.packages
@@ -2,18 +2,5 @@
 # Format:
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
-biosdevname=0.7.3-5.3.1
-dracut-kiwi-live=9.24.17-150100.3.50.1
 dracut-metal-mdsquash=2.2.0-1
-grub2-branding-SLE=15-33.3.1
-grub2-i386-pc=2.04-150300.22.20.2
-grub2-x86_64-efi=2.04-150300.22.20.2
-grub2=2.04-150300.22.20.2
-# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
-kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
 ledmon=0.94-1.59
-mdadm=4.1-150300.24.15.1
-# DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"
-mft=4.20.0-34
-tpm2.0-abrmd=2.3.3-3.3.1
-tpm2.0-tools=4.3.0-4.3.1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1865 CASMTRIAGE-3944

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Several packages such as `tpm` and `mft` can have hardware emulated from
Vagrant or Vshasta. This simply reshuffles the packages to ensure
someone testing a Vagrant box or Vshasta image can validate basics like
kernel packages.
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
