### PR TITLE
MTL-1865 Install `kdump`

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -49,6 +49,7 @@ iproute2-bash-completion=5.3-5.5.1
 ipset=6.36-3.3.1
 java-1_8_0-ibm-plugin=1.8.0_sr7.5-150000.3.56.1
 java-1_8_0-ibm=1.8.0_sr7.5-150000.3.56.1
+kdump=0.9.0-150300.18.8.1
 kdumpid=1.2-1.30
 kmod-bash-completion=29-4.15.1
 kubectl=1.21.12-0


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1865

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
The base ISO installs/provides `kdump`, but the base vagrant box does not. Since `kdump` isn't listed it is never installed otherwise, the vagrant builds need this package as well.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
