### PR TITLE
MTL-1925 MTL-1924 CASMPET-5428

### DIFF
--- a/packages/node-image-common/metal.packages
+++ b/packages/node-image-common/metal.packages
@@ -2,7 +2,7 @@
 # Format:
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
-dracut-metal-mdsquash=2.2.0-1
+dracut-metal-mdsquash=2.2.1-1
 ledmon=0.94-1.59
 haproxy=2.0.14-bp152.1.1
 keepalived=2.0.19-bp152.1.9

--- a/packages/node-image-kubernetes/metal.packages
+++ b/packages/node-image-kubernetes/metal.packages
@@ -2,5 +2,5 @@
 # Format:
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
-dracut-metal-dmk8s=2.0.4-1
+dracut-metal-dmk8s=2.0.5-1
 dracut-metal-luksetcd=2.0.4-1

--- a/packages/node-image-pre-install-toolkit/base.packages
+++ b/packages/node-image-pre-install-toolkit/base.packages
@@ -5,7 +5,7 @@
 
 # CSM Packages
 canu=1.6.13-1
-cray-site-init=1.24.2-1
+cray-site-init=1.25.0-1
 ilorest=3.5.1-1
 metal-basecamp=1.2.0-1
 metal-ipxe=2.2.8-1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1925 MTL-1924 CASMPET-5428

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
CASMPET-5428 new cray-site-init

Newer cray-site-init includes a few library/dependency updates

MTL-1924 new dracut-metal-dmk8s to resolve erroneous NVME output from
`partprobe`

MTL-1925 fix for `metal.ipv4`, an optional kernel param to toggle IPv4-only mode

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
