### PR TITLE
Add separate list of storage nodes for cephExporter endpoints (CASMPET-5428)

### DIFF
--- a/packages/node-image-pre-install-toolkit/base.packages
+++ b/packages/node-image-pre-install-toolkit/base.packages
@@ -5,7 +5,7 @@
 
 # CSM Packages
 canu=1.6.13-1
-cray-site-init=1.24.2-1
+cray-site-init=1.25.0-1
 ilorest=3.5.1-1
 metal-basecamp=1.2.0-1
 metal-ipxe=2.2.8-1


### PR DESCRIPTION
### Summary and Scope

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5428

#### Issue Type

- Bugfix Pull Request

Cephexporter only reports data on the first three storage nodes (running mon/mgr).

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)

```
C02YT3JRLVCJ:cray-site-init bklein$ cat foo/foo/customizations.yaml  | grep -A3 nmn_ncn_storage_mons
    nmn_ncn_storage_mons:
    - 10.252.1.4
    - 10.252.1.5
    - 10.252.1.6
```
 
### Idempotency
 
Good
 
### Risks and Mitigations
 
Low