### PR TITLE
Add separate list of storage nodes for cephExporter endpoints (CASMPET-5428)

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -15,7 +15,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.7-1
 
 # CSM METAL-team Packages
-cray-site-init=1.24.2-1
+cray-site-init=1.25.0-1
 ilorest=3.5.1-1
 kernel-default=5.3.18-150300.59.43.1
 kernel-firmware=20210208-150300.4.10.1


### PR DESCRIPTION
### Summary and Scope

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5428

#### Issue Type

- Bugfix Pull Request

Cephexporter only reports data on the first three storage nodes (running mon/mgr).

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)

```
C02YT3JRLVCJ:cray-site-init bklein$ cat foo/foo/customizations.yaml  | grep -A3 nmn_ncn_storage_mons
    nmn_ncn_storage_mons:
    - 10.252.1.4
    - 10.252.1.5
    - 10.252.1.6
```
 
### Idempotency
 
Good
 
### Risks and Mitigations
 
Low