### PR TITLE
CASMCMS-8087: Add BOSv2 support to cmsdev test tool

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -7,7 +7,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.6.1-1
+cray-cmstools-crayctldeploy=1.7.0-1
 platform-utils=1.3.5-1
 
 # COS


### PR DESCRIPTION
main backport of https://github.com/Cray-HPE/csm-rpms/pull/576