### PR TITLE
CASMCMS-8193: cmsdev test: Update BOS CLI test to reflect default version back to v1

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.7.0-1
+cray-cmstools-crayctldeploy=1.8.0-1
 loftsman=1.2.0-1
 manifestgen=1.3.7-1
 platform-utils=1.3.5-1


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMCMS-8193](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8193)
- Requires: [CASMCMS-8192](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8192)

This should merge at the same time as these PRs:
https://github.com/Cray-HPE/csm/pull/1225
https://github.com/Cray-HPE/csm-rpms/pull/589
https://github.com/Cray-HPE/csm/pull/1223

#### Issue Type

- RFE Pull Request

See source PR for details:
https://github.com/Cray-HPE/cms-tools/pull/53

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

See source PR for details:
https://github.com/Cray-HPE/cms-tools/pull/53

### Risks and Mitigations
 
If the CLI change merges and not this, there will be test failures.