### PR TITLE
CASMCMS-8193: cmsdev test: Update BOS CLI test to reflect default version back to v1

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -7,7 +7,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.7.0-1
+cray-cmstools-crayctldeploy=1.8.0-1
 platform-utils=1.3.5-1
 
 # COS


### PR DESCRIPTION
main backport of https://github.com/Cray-HPE/csm-rpms/pull/582

This should merge at the same time as the following PRs:
https://github.com/Cray-HPE/csm/pull/1224
https://github.com/Cray-HPE/csm/pull/1220
https://github.com/Cray-HPE/csm-rpms/pull/588
