### PR TITLE
CASMCMS-8192: Default the Cray CLI to v1 for BOS

### DIFF
--- a/packages/node-image-common/base.packages
+++ b/packages/node-image-common/base.packages
@@ -164,7 +164,7 @@ spire-agent=0.12.2-2.3_20220420125806__gf6cdaa8
 # CSM Team
 cray-kubectl-hns-plugin=1.0.0-1
 cray-kubectl-kubelogin-plugin=1.25.1-1
-craycli=0.61.0-1
+craycli=0.62.0-1
 csm-node-identity=1.0.18-1
 goss-servers=1.15.1-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77

--- a/packages/node-image-compute/base.packages
+++ b/packages/node-image-compute/base.packages
@@ -6,4 +6,4 @@ cfs-state-reporter=1.9.0-1
 cfs-trust=1.6.0-1
 cray-switchboard=1.2.3-1
 cray-uai-util=1.0.13-1
-craycli=0.61.0-1
+craycli=0.62.0-1


### PR DESCRIPTION
### Summary and Scope

See https://github.com/Cray-HPE/csm/pull/1220

This should merge at the same time as the following PRs:
https://github.com/Cray-HPE/csm-rpms/pull/582
https://github.com/Cray-HPE/csm/pull/1224
https://github.com/Cray-HPE/csm/pull/1220