### PR TITLE
CASMCMS-8203: Stop failing git commands from crashing cmsdev

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -7,7 +7,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.8.0-1
+cray-cmstools-crayctldeploy=1.8.1-1
 platform-utils=1.3.5-1
 
 # COS


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMCMS-8203](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8203)
- Relates to: [CASMTRIAGE-4074](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4074)

#### Issue Type

- Bugfix Pull Request

The cmsdev test crashes in a couple of error paths when it dereferences null pointers. The fix is very simple.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

Tested on starlord, where the problem was discovered. See source PR for details: https://github.com/Cray-HPE/cms-tools/pull/57

### Risks and Mitigations
 
Very low risk to include. Fix is extremely simple.
