### PR TITLE
Update craycli to 0.63.0; fix python3.6 deprecation warning

### DIFF
--- a/packages/node-image-common/base.packages
+++ b/packages/node-image-common/base.packages
@@ -164,7 +164,7 @@ spire-agent=0.12.2-2.3_20220420125806__gf6cdaa8
 # CSM Team
 cray-kubectl-hns-plugin=1.0.0-1
 cray-kubectl-kubelogin-plugin=1.25.1-1
-craycli=0.62.0-1
+craycli=0.63.0-1
 csm-node-identity=1.0.18-1
 goss-servers=1.15.7-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77

--- a/packages/node-image-compute/base.packages
+++ b/packages/node-image-compute/base.packages
@@ -6,4 +6,4 @@ cfs-state-reporter=1.9.0-1
 cfs-trust=1.6.0-1
 cray-switchboard=1.2.3-1
 cray-uai-util=1.0.13-1
-craycli=0.62.0-1
+craycli=0.63.0-1


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMCLOUD-1212](https://jira-pro.its.hpecorp.net:8443/browse/CASMCLOUD-1212)

#### Issue Type

- Bugfix Pull Request

Update craycli to 0.63.0 to fix python 3.6 deprecation warning.

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)

Ran the offending command from the ticket and verified that the deprecation warning no longer occurs.

### Risks and Mitigations
 
The risk for this is low since we are simply moving the boto3 and botocore modules back to previously used versions in the CLI.  Without this fix, users see a potentially unsettling deprecation warning that has no bearing on actual reality because of the way the CLI is packaged and installed.
