### PR TITLE
CASMCMS-8210/CASMCMS-8212: cmsdev: Add BOS CLI tests, resolve CVE

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.8.1-1
+cray-cmstools-crayctldeploy=1.9.0-1
 loftsman=1.2.0-1
 manifestgen=1.3.7-1
 platform-utils=1.3.5-1

--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.9.0-1
+cray-cmstools-crayctldeploy=1.10.0-1
 loftsman=1.2.0-1
 manifestgen=1.3.7-1
 platform-utils=1.3.5-1


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMCMS-8210](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8210)
  - Adds 3 overlooked BOS CLI tests to the cmsdev test tool. See source PR for full details: https://github.com/Cray-HPE/cms-tools/pull/58
- Fixed [CASMCMS-8212](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8212)
  - Updated Golang version and dependent modules to [resolve High severity CVE](https://github.com/Cray-HPE/cms-tools/security/dependabot/1). See source PR for full details: https://github.com/Cray-HPE/cms-tools/pull/60

#### Issue Type

- RFE Pull Request

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

New subtests were run successfully on surtur. See source PR for full details:
https://github.com/Cray-HPE/cms-tools/pull/58

Rebuilt binary with CVE remediations was tested on fanta. See source PR for full details: https://github.com/Cray-HPE/cms-tools/pull/60

### Risks and Mitigations
 
The risk of adding these new subtests is small because they are very basic tests that re-use existing test code.
And the risk of not remediating the CVE seems higher than the update to fix it.