### PR TITLE
HPCCHT3-3457 cray-sdu-rda 2.1.1

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -22,4 +22,4 @@ cray-prodmgr=1.1.6-1
 cray-sat-podman=2.0.0-1
 
 # SDU
-cray-sdu-rda=2.1.0-shasta_20220810231129_03043fd
+cray-sdu-rda=2.1.1-shasta_20220919150932_ec06814

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -10,4 +10,4 @@ https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.3/sle15
 https://artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3/                                        cray-algol60-sat-rpms-stable-sle-15sp3            --no-gpgcheck -p 88                   cray/sat/sle-15sp3
 
 # SDU
-https://arti.dev.cray.com/artifactory/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn/              sdu-rpm-stable-local                              --no-gpgcheck -p 89                   sdu-rpm-stable-local/release/2.1/sle15_sp3_ncn/
+https://arti.hpc.amslabs.hpecorp.net/artifactory/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn/              sdu-rpm-stable-local                              --no-gpgcheck -p 89                   sdu-rpm-stable-local/release/2.1/sle15_sp3_ncn/

--- a/repos/cray.repos
+++ b/repos/cray.repos
@@ -10,4 +10,4 @@ https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.3/sle15
 https://artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3/                                        cray-algol60-sat-rpms-stable-sle-15sp3            --no-gpgcheck -p 88                   cray/sat/sle-15sp3
 
 # SDU
-https://arti.hpc.amslabs.hpecorp.net/artifactory/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn/              sdu-rpm-stable-local                              --no-gpgcheck -p 89                   sdu-rpm-stable-local/release/2.1/sle15_sp3_ncn/
+https://arti.hpc.amslabs.hpecorp.net/artifactory/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn/   sdu-rpm-stable-local                              --no-gpgcheck -p 89                   sdu-rpm-stable-local/release/2.1/sle15_sp3_ncn/


### PR DESCRIPTION
### Summary and Scope

[HPCCHT3-3457](https://jira-pro.its.hpecorp.net:8443/browse/HPCCHT3-3457) : "Build, test and release cray-sdu-rda-2.1.1"

- Fixes: See the [release page](https://jira-pro.its.hpecorp.net:8443/projects/HPCCHT3/versions/58373) for details on what is going into this release.
- Requires: N/A
- Relates to: N/A

#### Issue Type

- Bugfix Pull Request
- Docs Pull Request

This will update the cray-sdu-rda RPM installation into the base NCN image from cray-sdu-rda-2.1.0 to cray-sdu-rda-2.1.1. Additionally, the base URL from which to retrieve the RPM has been updated.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
All of the changes in this release are either bug fixes or documentation changes. As a result, the risk is overall reduced.

The main bug fix in this release was a segmentation fault that was encountered at cray-sdu-rda service start up time when upgrading from some versions.
