### PR TITLE
HPCCHT3-3493 build test release cray sdu rda 2.1.2 shasta release

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -25,4 +25,4 @@ cray-prodmgr=1.1.2-20220104153307_2374f1f
 cray-sat-podman=2.0.0-1
 
 # SDU
-cray-sdu-rda=2.1.1-shasta_20220919150932_ec06814
+cray-sdu-rda=2.1.2-shasta_20221006164635_402e1db


### PR DESCRIPTION
### Summary and Scope
[HPCCHT3-3493](https://jira-pro.its.hpecorp.net:8443/browse/HPCCHT3-3493)

[release notes](https://jira-pro.its.hpecorp.net:8443/projects/HPCCHT3/versions/58922) for the changes needed for the cray-sdu-rda-2.1.2 release targeting Papaya: 

The main goal of these changes is to fix a minor bug related to cray-sdu-rda version transitioning.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
    - Test results found [here](https://github.hpe.com/hpe/hpc-ch-sdu-tarfile-shasta/tree/d05317c39977af72c2781106e45ce2993246b930/testing/HPCCHT3-3493_2.1.2_release).
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

There is minimal risk to the base NCN image as the code loaded is inoperable until the associated OCI image is loaded into Nexus and an admin/customer starts the cray-sdu-rda service.

-->
