### PR TITLE
CASMINST-5313 Vagrant OS Test Harness Deps.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,7 @@
 
 - [ ] I have included documentation in my PR (or it is not required)
 - [ ] I tested this on internal system (if yes, please include results or a description of the test)
+- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
 - [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
 ### Risks and Mitigations

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -59,6 +59,7 @@ pipeline {
           ./scripts/update-package-versions.sh -p packages/node-image-common/base.packages --validate --suffix ${env.SUFFIX}
           ./scripts/update-package-versions.sh -p packages/node-image-common/google.packages --validate --suffix ${env.SUFFIX}
           ./scripts/update-package-versions.sh -p packages/node-image-common/metal.packages --validate --suffix ${env.SUFFIX}
+          ./scripts/update-package-versions.sh -p packages/node-image-common/vagrant.packages --validate --suffix ${env.SUFFIX}
         """
       }
     }

--- a/packages/node-image-common/vagrant.packages
+++ b/packages/node-image-common/vagrant.packages
@@ -1,0 +1,5 @@
+# Vagrant only packages
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).
+qemu-guest-agent=5.2.0-150300.115.2

--- a/packages/node-image-kubernetes/vagrant.packages
+++ b/packages/node-image-kubernetes/vagrant.packages
@@ -1,0 +1,4 @@
+# Vagrant only packages
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).

--- a/packages/node-image-pre-install-toolkit/vagrant.packages
+++ b/packages/node-image-pre-install-toolkit/vagrant.packages
@@ -1,0 +1,4 @@
+# Vagrant only packages
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).

--- a/packages/node-image-storage-ceph/vagrant.packages
+++ b/packages/node-image-storage-ceph/vagrant.packages
@@ -1,0 +1,4 @@
+# Vagrant only packages
+# Format:
+#   package_name=version
+# The version is the same version reported by the OS package manager (e.g. zypper).


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: CASMINST-5313

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
The `qemu-guest-agent` package was being slurped into Dennis' repacking of the `.qcow2` files when making a `.box`. To use native boxes we need to install this into the native boxes during the build, then we don't need to repack it like Dennis is currently doing.

This adds a `vagrant.packages` files.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
