### PR TITLE
CASMINST-5422

### DIFF
--- a/build/resolve-packages.sh
+++ b/build/resolve-packages.sh
@@ -30,7 +30,7 @@ cat "$@" \
 | docker run -i \
     --cidfile "${workdir}/container-id" \
     -v "$(realpath "$ROOTDIR"):/data" \
-    arti.dev.cray.com/baseos-docker-master-local/sles15sp3:latest \
+    artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.3 \
     bash -c "set -exo pipefail
     {
         source /data/scripts/rpm-functions.sh

--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -10,10 +10,6 @@ kubelet=1.21.12-0
 cray-cmstools-crayctldeploy=1.10.0-1
 platform-utils=1.3.5-1
 
-# COS
-cray-cps-utils=0.11.0-2.3_20220329162848__gfb2fe6a
-cray-orca=0.9.1-2.3_20220329135308__g8f2d4d6
-
 # DVS
 insserv-compat=0.1-4.6.1
 

--- a/repos/cray.template.repos
+++ b/repos/cray.template.repos
@@ -3,11 +3,11 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/      
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/                                        cray-algol60-csm-rpms-stable-sle-15sp3            --no-gpgcheck -p 88                   cray/csm/sle-15sp3
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/                                        cray-algol60-csm-rpms-stable-sle-15sp2            --no-gpgcheck -p 89                   cray/csm/sle-15sp2
 
-# COS
-https://arti.dev.cray.com/artifactory/cos-rpm-stable-local/release/cos-2.3/sle15_sp3_ncn/                         cray-cos-sle-15sp3-SHASTA-OS-cos                  --no-gpgcheck -p 89                   cray/cos/sle-15sp3-ncn
-
 # SAT
 https://artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3/                                        cray-algol60-sat-rpms-stable-sle-15sp3            --no-gpgcheck -p 88                   cray/sat/sle-15sp3
 
+# COS
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.3/sle15_sp3_ncn/              cray-cos-sle-15sp3-SHASTA-OS-cos                  --no-gpgcheck -p 89                   arti-rpm-mirror/cos-rpm-stable-local/release/cos-2.3/sle15_sp3_ncn/
+
 # SDU
-https://arti.hpc.amslabs.hpecorp.net/artifactory/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn/   sdu-rpm-stable-local                              --no-gpgcheck -p 89                   sdu-rpm-stable-local/release/2.1/sle15_sp3_ncn/
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn/   sdu-rpm-stable-local                              --no-gpgcheck -p 89                   arti-rpm-mirror/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn/

--- a/scripts/rpm-functions.sh
+++ b/scripts/rpm-functions.sh
@@ -47,6 +47,7 @@ EOF
 }
 
 function list-cray-repos-files() {
+  /usr/bin/envsubst < ${CSM_RPMS_DIR}/repos/cray.template.repos > ${CSM_RPMS_DIR}/repos/cray.repos
   cat <<EOF
 ${CSM_RPMS_DIR}/repos/cray.repos
 EOF


### PR DESCRIPTION
### Summary and Scope

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5422
- Relates to: https://jira-pro.its.hpecorp.net:8443/browse/MTL-1887

#### Issue Type

- RFE Pull Request

We're moving to github actions runners which do not have access to internally hosted artifacts required for builds.
- removes two unnecessary packages (cray-cps-utils and cray-orca) see Dean's comments in: https://jira-pro.its.hpecorp.net:8443/browse/MTL-1879
- makes cray.repos -> cray.template.repos to allow auth for artifactory.algol60.net
- updates COS / SDU repo locations (now on artifactory.algol60.net)
- updates rpm-functions.sh to support cray templated repos 

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations

Minimal risk. This is part of a greater effort to move away from build dependencies on internal HPE systems. 
