### PR TITLE
CASMHMS-5782 Fix snmp configure script

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -154,7 +154,7 @@ craycli=0.63.0-1
 csm-node-identity=1.0.18-1
 goss-servers=1.14.60-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
-hpe-csm-scripts=0.0.38-1
+hpe-csm-scripts=0.3.0-1
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 
 # Metal


### PR DESCRIPTION
## Summary and Scope
The script that configures SNMP on Dell and Aruba switches expects a user to delete from the Aruba switches. Unfortunately the delete happens after the creation of the new user and if they are the same name, the new user is deleted leaving the switch as it was before the script is executed. Updated the script to not require the delete user name. This allows both a creation method and a way to delete bad user names.

Behavior will not change when the same command line from the documentation is used.

## Issues and Related PRs

* Resolves [CASMHMS-5782](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5782)
* Documentation changes required in [CASMHMS-5782](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5782)

## Testing
### Tested on:

  * `loki`

### Test description:

Copied a modified version of the script to loki and executed with an alternative username for the Aruba SNMPv3 configuration. Validated that I could create the new user without deleting it and then create a new users while deleting the old bad user.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - N/A
- Was upgrade tested? If not, why? N - Installed via RPM
- Was downgrade tested? If not, why? N - Installed via RPM
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

