### PR TITLE
Ignore `cray.repos`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # ignore template files
+cray.repos
 google.repos
 hpe.repos
 suse.repos


### PR DESCRIPTION
Since `cray.repos` is a template file now, the produced template needs to be ignored. This change originated from #633.
