### PR TITLE
CASMCLOUD-1214 Newer `manifestgen`

### DIFF
--- a/packages/node-image-common/base.packages
+++ b/packages/node-image-common/base.packages
@@ -174,7 +174,7 @@ hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.4.1-1
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 loftsman=1.2.0-1
-manifestgen=1.3.7-1
+manifestgen=1.3.8-1
 
 # Metal Team
 kernel-default=5.3.18-150300.59.87.1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMCLOUD-1214

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Built against Python3.10 to keep the code current, and built with updated dependencies.

- https://github.com/Cray-HPE/manifestgen/pull/17
- https://github.com/Cray-HPE/manifestgen/pull/18
- https://github.com/Cray-HPE/manifestgen/pull/19
- https://github.com/Cray-HPE/manifestgen/pull/20
- https://github.com/Cray-HPE/manifestgen/pull/22

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)


`manifestgen` successfully produces a `manifest.yaml` file, and all unit tests pass.

```bash
redbull-ncn-m001-pit:/var/www/ephemeral/prep # manifestgen --version
manifestgen 1.3.8
redbull-ncn-m001-pit:/var/www/ephemeral/prep # rpm ^C
redbull-ncn-m001-pit:/var/www/ephemeral/prep # cd ^C
redbull-ncn-m001-pit:/var/www/ephemeral/prep # rm manifest.yaml
(reverse-i-search)`manife': rpm -Uvh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp2/manifestgen/x86_64/^Cnifestgen-1.3.8-1.x86_64.rpm
redbull-ncn-m001-pit:/var/www/ephemeral/prep # manifestgen -c site-init/customizations.yaml -i /tmp/platform.yaml -o manifest.yaml
redbull-ncn-m001-pit:/var/www/ephemeral/prep # head !$
head manifest.yaml
apiVersion: manifests/v1beta1
metadata:
  name: platform
spec:
  charts:
  - name: cray-metrics-server
    namespace: kube-system
    source: csm-algol60
    version: 0.4.0
  - name: cray-drydock
```

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
