### PR TITLE
CASMPET-6145:  Bump cray-site-init to 1.28.0

### DIFF
--- a/packages/node-image-pre-install-toolkit/base.packages
+++ b/packages/node-image-pre-install-toolkit/base.packages
@@ -5,7 +5,7 @@
 
 # CSM Packages
 canu=1.6.20-1
-cray-site-init=1.27.7-1
+cray-site-init=1.28.0-1
 ilorest=3.5.1-1
 metal-basecamp=1.2.2-1
 metal-ipxe=2.2.11-1


### PR DESCRIPTION
### Summary and Scope

Add cilium-operator-replicas, k8s-primary-cni, and kube-proxy-replacement to CSI.
