### PR TITLE
MTL-2004 `cray-chrony-dracut` for UAN

### DIFF
--- a/packages/node-image-application/base.packages
+++ b/packages/node-image-application/base.packages
@@ -4,6 +4,7 @@
 # The version is the same version reported by the OS package manager (e.g. zypper).
 cfs-state-reporter=1.9.0-1
 cray-auth-utils=0.3.1-2.4_20220805020814__ga82f924
+cray-chrony-dracut=1.4.0-2.4_20220805040923__g6c82b5c
 cray-spire-dracut=1.5.3-2.4_20220805032324__gdeb29a2
 csm-node-identity=1.0.18-1
 spire-agent=0.12.2-2.4_20220805014211__gd8c3376


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #663 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Stock SLES UAN currently aligns to the compute image. Adds `cray-chrony-dracut` and swaps `csm-node-identity` for `cray-node-identity` to align with compute images.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
