### PR TITLE
MTL-2045 artifactory auth

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -40,12 +40,14 @@ pipeline {
 
     environment {
         SUFFIX = "${env.JOB_BASE_NAME.replaceAll("%2F", "-").toLowerCase()}-${env.BUILD_NUMBER}"
+        DOCKER_REGISTRY = "https://artifactory.algol60.net/csm-docker/stable"
     }
 
     stages {
         stage('Setup Docker Cache') {
             steps {
                 withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
+                    sh "docker login ${env.DOCKER_REGISTRY} --username \$ARTIFACTORY_USER --password \$ARTIFACTORY_TOKEN"
                     sh "./scripts/update-package-versions.sh --refresh --no-cache --suffix ${env.SUFFIX}"
                     sh "./scripts/update-package-versions.sh --compute --refresh --no-cache --suffix ${env.SUFFIX}"
                 }

--- a/repos/cray.template.repos
+++ b/repos/cray.template.repos
@@ -1,10 +1,10 @@
 # CSM / CLOUD / PET / MTL / NET
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4                                                                                                                                      cray-algol60-csm-rpms-stable-sle-15sp4            --no-gpgcheck -p 88                   cray/csm/sle-15sp4
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3                                                                                                                                      cray-algol60-csm-rpms-stable-sle-15sp3            --no-gpgcheck -p 89                   cray/csm/sle-15sp3
-https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2                                                                                                                                      cray-algol60-csm-rpms-stable-sle-15sp2            --no-gpgcheck -p 90                   cray/csm/sle-15sp2
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4                                                                                                                                      cray-algol60-csm-rpms-stable-sle-15sp4            --no-gpgcheck -p 88                   cray/csm/sle-15sp4
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3                                                                                                                                      cray-algol60-csm-rpms-stable-sle-15sp3            --no-gpgcheck -p 89                   cray/csm/sle-15sp3
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2                                                                                                                                      cray-algol60-csm-rpms-stable-sle-15sp2            --no-gpgcheck -p 90                   cray/csm/sle-15sp2
 
 # SAT
-https://artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3                                                                                                                                      cray-algol60-sat-rpms-stable-sle-15sp3            --no-gpgcheck -p 88                   cray/sat/sle-15sp3
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3                                                                                                                                      cray-algol60-sat-rpms-stable-sle-15sp3            --no-gpgcheck -p 88                   cray/sat/sle-15sp3
 
 # COS
 # NOTE: Includes SP3 with an older priority because cray-heartbeat isn't built for SP4 (yet - SKERN-7383)


### PR DESCRIPTION
### Summary and Scope

Add artifactory authentication for zypper repos and docker

https://jira-pro.its.hpecorp.net:8443/browse/MTL-2045


#### Issue Type

- RFE Pull Request

artifactory.algol60.net is in the process of being locked down, so authentication will soon be required for accessing all repos.

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations

Minimal risk. The authentication method we're using is already used in this repo and others.