### PR TITLE
CASMHMS-5689 Fix for unset variable in set_ssh_keys.py

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -4,7 +4,7 @@ cray-heartbeat=1.2.2-2.1_6.16__gf6fd0bd.shasta
 cray-power-button=1.2.2-2.1_20210930095544__g3d80145
 craycli=0.46.0
 csm-node-identity=1.0.18-1
-hpe-csm-scripts=0.2.0-1
+hpe-csm-scripts=0.2.1-1
 
 # CSM Testing Utils
 goss-servers=1.12.38-1


### PR DESCRIPTION
## Summary and Scope

The set_ssh_keys.py script has a bug in it where it does not properly set a variable and ends up skipping all BMCs other than switch controllers when setting ssh keys. This change reworks an if statement to properly set the variable in all cases.

## Issues and Related PRs

* Resolves [CASMHMS-5689](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5689)

## Testing

### Tested on:

  * `hela`

### Test description:

Code changes were done on hela to fix the problem. The script was then copied to the source.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - N/A
- Was upgrade tested? If not, why? N - Installed via RPM
- Was downgrade tested? If not, why? N - Installed via RPM
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

