### PR TITLE
CASMHMS-5771 cray cli 0.66.0

### DIFF
--- a/packages/node-image-base/base.packages
+++ b/packages/node-image-base/base.packages
@@ -111,7 +111,7 @@ zsh=5.6-7.5.1
 
 # CSM Team
 csm-node-identity=1.0.19-1
-craycli=0.65.0-1
+craycli=0.66.0-1
 
 # Metal Team
 kernel-default=5.14.21-150400.24.33.2


### PR DESCRIPTION


### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Requires: https://github.com/Cray-HPE/csm/pull/1584


#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request: [CASMHMS-5771](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5771)


Removed the SLS option to get credentials. This removes the options to pass public and private keys to sls dumpstate and loadstate.


### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
This is low risk. It removes cray cli features that we believe the customer does not use. The removed cray cli options only recently started working.
