### PR TITLE
Revert "CASMTRIAGE-4697 Downgrade the kernel (#681)"

### DIFF
--- a/packages/node-image-base/base.packages
+++ b/packages/node-image-base/base.packages
@@ -114,11 +114,11 @@ csm-node-identity=1.0.19-1
 craycli=0.66.0-1
 
 # Metal Team
-kernel-default=5.14.21-150400.22.1
+kernel-default=5.14.21-150400.24.33.2
 kernel-firmware-all=20220509-150400.4.13.1
-kernel-macros=5.14.21-150400.22.1
-kernel-source=5.14.21-150400.22.1
-kernel-syms=5.14.21-150400.22.1
+kernel-macros=5.14.21-150400.24.33.1
+kernel-source=5.14.21-150400.24.33.1
+kernel-syms=5.14.21-150400.24.33.1
 
 # Python3 RPM Packages
 # These support applications that do not install into virtualenvs, and that need airgap support.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: CASMTRIAGE-4697

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This reverts commit 2000860ec60c4652d383dcb5b435cbaa5f27d56a.

MTL-2053 was successful, so we will not downgrade the kernel but instead use the official PTF kernel that includes a patch for CASMTRIAGE-4697.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
