### PR TITLE
CASMTRIAGE-4697 Kernel update

### DIFF
--- a/packages/node-image-base/base.packages
+++ b/packages/node-image-base/base.packages
@@ -114,11 +114,11 @@ csm-node-identity=1.0.19-1
 craycli=0.66.0-1
 
 # Metal Team
-kernel-default=5.14.21-150400.24.33.2
+kernel-default=5.14.21-150400.24.38.1.25440.1.PTF.1204911
 kernel-firmware-all=20220509-150400.4.13.1
-kernel-macros=5.14.21-150400.24.33.1
-kernel-source=5.14.21-150400.24.33.1
-kernel-syms=5.14.21-150400.24.33.1
+kernel-macros=5.14.21-150400.24.38.1.25440.1.PTF.1204911
+kernel-source=5.14.21-150400.24.38.1.25440.1.PTF.1204911
+kernel-syms=5.14.21-150400.24.38.1.25440.1.PTF.1204911
 
 # Python3 RPM Packages
 # These support applications that do not install into virtualenvs, and that need airgap support.

--- a/repos/suse.template.repos
+++ b/repos/suse.template.repos
@@ -88,3 +88,7 @@ https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifac
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/openSUSE:Backports:SLE-15-SP4/step/                                          openSUSE-Backports-SLE-15-SP4-step                                    -g -p 89  openSUSE:Backports:SLE-15-SP4/step/
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/openSUSE:Backports:SLE-15-SP4/standard/                                      openSUSE-Backports-SLE-15-SP4-standard                                -g -p 89  openSUSE:Backports:SLE-15-SP4/standard/
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/filesystems:ceph:quincy:upstream/openSUSE_Leap_15.4/                         filesystems-ceph                                                      -g -p 89  openSUSE_Leap_15.4/
+
+
+# SUSE PTF Packages
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/suse-external/PTF/15-SP4/SLE-Module-Basesystem/                                              SUSE-SLE-Module-Basesystem-PTF-15-SP4                                 -g -p 79  suse/SLE-Module-Basesystem-PTF/15-SP4/


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-4697

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Pull in the PTF update from SUSE which includes the vetted fix for CASMTRIAGE-4697.
This updates the kernel to `5.14.21-150400.24.38.1.25440.1.PTF.1204911`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
