### PR TITLE
MTL-2058 Package updates

### DIFF
--- a/packages/node-image-base/base.packages
+++ b/packages/node-image-base/base.packages
@@ -12,11 +12,11 @@ bsdtar=3.5.1-150400.3.12.1
 chrony=4.1-150400.19.4
 crash=7.3.0-150400.3.2.6
 cryptsetup=2.4.3-150400.1.110
-curl=7.79.1-150400.5.9.1
+curl=7.79.1-150400.5.12.1
 dkms=2.6.1-bp154.1.30
 dmidecode=3.4-150400.16.3.1
 dosfstools=4.1-3.6.1
-dracut-kiwi-live=9.24.36-150100.3.53.2
+dracut-kiwi-live=9.24.43-150100.3.56.3
 dump=0.4b47-150400.1.10
 ebtables=2.0.11-1.1
 elfutils-lang=0.185-150400.5.3.1
@@ -39,7 +39,7 @@ hdparm=9.62-150400.1.7
 hwloc=2.5.0-150400.1.9
 iproute2-bash-completion=5.14-150400.1.8
 iproute2=5.14-150400.1.8
-iputils=20211215-150400.1.5
+iputils=20211215-150400.3.3.2
 issue-generator=1.7-1.17
 kdump=1.0.2+git14.gb49d4a3-150400.3.5.1
 kdumpid=1.3-150400.1.4
@@ -52,8 +52,8 @@ libdw1=0.185-150400.5.3.1
 libecpg6=14.5-150200.5.17.1
 libelf-devel=0.185-150400.5.3.1
 libelf1=0.185-150400.5.3.1
-libfreebl3-hmac=3.79.2-150400.3.15.1
-libfreebl3=3.79.2-150400.3.15.1
+libfreebl3-hmac=3.79.2-150400.3.18.1
+libfreebl3=3.79.2-150400.3.18.1
 liblldp_clif1=1.1+44.0f781b4162d3-3.3.1
 libopenssl1_1=1.1.1l-150400.7.16.1
 libpq5=14.5-150200.5.17.1
@@ -65,12 +65,12 @@ lsscsi=0.28-1.24
 lvm2=2.03.05-150400.185.1
 man=2.7.6-6.22
 open-lldp=1.1+44.0f781b4162d3-3.3.1
-openscap-utils=1.3.5-150400.9.8
-openscap=1.3.5-150400.9.8
-openssh-clients=8.4p1-150300.3.12.2
-openssh-common=8.4p1-150300.3.12.2
-openssh-server=8.4p1-150300.3.12.2
-openssh=8.4p1-150300.3.12.2
+openscap-utils=1.3.6-150400.11.3.1
+openscap=1.3.6-150400.11.3.1
+openssh-clients=8.4p1-150300.3.15.4
+openssh-common=8.4p1-150300.3.15.4
+openssh-server=8.4p1-150300.3.15.4
+openssh=8.4p1-150300.3.15.4
 openssl-1_1=1.1.1l-150400.7.16.1
 parted=3.2-19.1
 pciutils=3.5.6-150300.13.3.1
@@ -90,12 +90,12 @@ python310-devel=3.10.8-150400.4.15.1
 python310=3.10.8-150400.4.15.1
 python3=3.6.15-150300.10.37.2
 rsync=3.2.3-150400.3.8.1
-rsyslog=8.2106.0-150400.5.6.1
+rsyslog=8.2106.0-150400.5.11.1
 scap-security-guide=0.1.64-150000.1.50.1
 screen=4.6.2-5.3.1
 strace=5.14-150400.1.7
 supportutils=3.1.21-150300.7.35.15.1
-sudo=1.9.9-150400.4.6.1
+sudo=1.9.9-150400.4.9.1
 tar=1.34-150000.3.22.3
 tcpdump=4.99.1-150400.1.8
 tmux=3.1c-bp152.2.3.1
@@ -112,7 +112,7 @@ zip=3.0-2.22
 zsh=5.6-7.5.1
 
 # CSM Team
-csm-node-identity=1.0.19-1
+csm-node-identity=1.0.20-1
 craycli=0.66.0-1
 
 # Metal Team
@@ -121,6 +121,10 @@ kernel-firmware-all=20220509-150400.4.13.1
 kernel-macros=5.14.21-150400.24.38.1.25440.1.PTF.1204911
 kernel-source=5.14.21-150400.24.38.1.25440.1.PTF.1204911
 kernel-syms=5.14.21-150400.24.38.1.25440.1.PTF.1204911
+# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
+kernel-mft-mlnx-kmp-default=4.21.0_k5.14.21_150400.22-1.sles15sp4
+# DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"
+mft=4.21.0-99
 
 # Python3 RPM Packages
 # These support applications that do not install into virtualenvs, and that need airgap support.
@@ -131,7 +135,7 @@ python3-boto3=1.23.4-150200.23.9.1
 python3-click=7.0-1.27
 python3-colorama=0.4.4-5.4.1
 python3-defusedxml=0.6.0-1.42
-python3-gobject=3.42.0-150400.1.48
+python3-gobject=3.42.2-150400.3.3.2
 python3-ipaddr=2.1.11-2.24
 python3-kubernetes=8.0.1-150100.3.7.1
 python3-lxml=4.7.1-150200.3.10.1

--- a/packages/node-image-compute/base.packages
+++ b/packages/node-image-compute/base.packages
@@ -13,7 +13,7 @@ libcairo-gobject2=1.16.0-150400.9.6
 libcairo2=1.16.0-150400.9.6
 libgcrypt20=1.9.4-150400.6.5.1
 libgdk_pixbuf-2_0-0=2.42.9-150400.5.6.1
-libgio-2_0-0=2.70.4-150400.1.5
+libgio-2_0-0=2.70.5-150400.3.3.1
 libglvnd=1.3.3-150400.3.4
 libgtk-3-0=3.24.34-150400.3.3.1
 libgtksourceview-3_0-1=3.24.11-150400.10.11
@@ -37,12 +37,12 @@ typelib-1_0-Gtk-3_0=3.24.34-150400.3.3.1
 cray-auth-utils=0.3.1-2.4_20220907191100__gecf64bc
 cray-ckdump-helper=2.11.2-2.4_20220907192738__g2f4338a
 cray-chrony-dracut=1.4.0-2.4_20220907211223__gf7f4743
-cray-heartbeat=1.8.2-2.4_4.19__g5712ad4.shasta
+cray-heartbeat=1.8.2-2.4_4.20__g5712ad4.shasta
 cray-hugepage-setup=0.6.1-2.4_20220907195721__g8a72bcc
 cray-network-dracut=1.3.1-2.4_20220907212221__ga511757
 cray-power-button=1.4.1-2.4_20220907233542__g35e8b4a
 cray-system-files=1.13.5-2.4_20220927102737__g81928fa
-cray-system-setup-scripts=1.3.2-2.4_20220907182749__ga5ea373
+cray-system-setup-scripts=1.3.3-2.4_20221215171734__gf3a8090
 cray-systemd-presets=1.6.1-2.4_20220907233542__gf8b34cc
 cray-udev-network-cn=1.6.18-2.4_20221025121011__ga8be192
 spire-agent=0.12.2-2.4_20220907184947__ge83309b
@@ -59,8 +59,8 @@ cray-low-noise-mode=1.2.3-2.4_20220907223914__gb6477c9
 # - cray-libhugetlbfs-devel             :
 # - cray-rasdaemon                      :
 acpid=2.0.31-1.1_2.4_20220907164401__g5cfe682
-cray-libhugetlbfs=2.20_2.1.29-2.4_3.12__g05da5a8.shasta
-cray-libhugetlbfs-devel=2.20_2.1.29-2.4_3.12__g05da5a8.shasta
+cray-libhugetlbfs=2.20_2.1.29-2.4_3.13__g05da5a8.shasta
+cray-libhugetlbfs-devel=2.20_2.1.29-2.4_3.13__g05da5a8.shasta
 cray-rasdaemon=0.6.8-3_2.4_20220907184629__gdb74487
 
 # GPU Support Packages

--- a/packages/node-image-ncn-common/base.packages
+++ b/packages/node-image-ncn-common/base.packages
@@ -16,7 +16,7 @@ gperftools=2.5-4.12
 gptfdisk=1.0.8-150400.1.7
 hplip=3.21.10-150400.3.5.1
 ipmitool=1.8.18.238.gb7adc1d-150400.1.14
-ipset=6.36-3.3.1
+ipset=7.15-150400.12.3.2
 java-1_8_0-ibm-plugin=1.8.0_sr7.20-150000.3.65.1
 java-1_8_0-ibm=1.8.0_sr7.20-150000.3.65.1
 jq=1.6-3.3.1
@@ -30,14 +30,14 @@ minicom=2.7.1-1.19
 mlocate=0.26-150400.14.5
 netcat-openbsd=1.203-150400.1.5
 nmap=7.92-150400.1.8
-pdsh=2.34-32.1
+pdsh=2.34-150300.35.2
 podman-cni-config=3.4.7-150400.4.6.1
 podman=3.4.7-150400.4.6.1
 postgresql-contrib=14-150400.4.3.88
 postgresql-docs=14-150400.4.3.88
 postgresql-server=14-150400.4.3.88
 postgresql=14-150400.4.3.88
-rarpd=20211215-150400.1.5
+rarpd=20211215-150400.3.3.2
 rasdaemon=0.6.7.18.git+7ccf12f-150400.2.7
 rollback-helper=1.0+git20181218.5394d6e-4.3.1
 rzsz=0.12.21~rc-150000.3.3.2
@@ -49,7 +49,7 @@ squid=5.7-150400.3.6.1
 sysstat=12.0.2-3.33.1
 systemtap=4.6-150400.1.7
 wget=1.20.3-150000.3.15.1
-wireshark=3.6.8-150000.3.74.1
+wireshark=3.6.10-150000.3.78.1
 xfsdump=3.1.6-1.30
 
 # COS
@@ -69,7 +69,6 @@ cfs-trust=1.6.2-1
 # CSM Team
 cray-kubectl-hns-plugin=1.0.1-1
 cray-kubectl-kubelogin-plugin=1.25.2-1
-csm-node-identity=1.0.19-1
 goss-servers=1.15.24-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.4.3-1
@@ -77,8 +76,3 @@ hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 loftsman=1.2.0-1
 manifestgen=1.3.9-1
 
-# Metal Team
-# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
-kernel-mft-mlnx-kmp-default=4.21.0_k5.14.21_150400.22-1.sles15sp4
-# DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"
-mft=4.21.0-99


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2058

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Numerous misc. package updates to pull in before we ship 1.4.0-alpha.29. 1.4.0-alpha.29 has the working/fixed SP4 kernel, that makes 1.4.0-alpha.29 the first CSM 1.4 release with SP4 that other teams can use. This means we will be inspecting CVEs much more closely, so taking another stab at updating to the most recent latest of thes packages is a good idea.

This also moves some packages out of node-image-ncn-common and into base, namely:
- mft
- kernel-mft-mlnx-kmp-default

This also removes csm-node-identity from node-image-ncn-common because it is already defined in node-image-base.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
