### PR TITLE
CASMINST-5793: csm-testing: Log test duration in decimal without scientific notation

### DIFF
--- a/packages/node-image-ncn-common/base.packages
+++ b/packages/node-image-ncn-common/base.packages
@@ -69,7 +69,7 @@ cfs-trust=1.6.2-1
 # CSM Team
 cray-kubectl-hns-plugin=1.0.1-1
 cray-kubectl-kubelogin-plugin=1.25.2-1
-goss-servers=1.15.24-1
+goss-servers=1.15.27-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.4.3-1
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMINST-5793](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5793)
- [1.4 source PR](https://github.com/Cray-HPE/csm-testing/pull/427)
- [main source PR](https://github.com/Cray-HPE/csm-testing/pull/428)
- [1.4 csm manifest PR](https://github.com/Cray-HPE/csm/pull/1633)
- [main csm manifest PR](https://github.com/Cray-HPE/csm/pull/1634)
- [main csm-rpms manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/698)

#### Issue Type

- Bugfix Pull Request
- RFE Pull Request

In csm-testing, print_goss_json_results was logging test duration in seconds using scientific notation (this was happening implicitly, by the Python JSON module). This was unable to be consumed by the grok exporter tool being used to collect the Goss test logs. This PR changes things so that scientific notation is not used. It also fixes a few minor bugs in error paths of print_goss_json_results .

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

See [1.4 source PR](https://github.com/Cray-HPE/csm-testing/pull/427) for details.

### Risks and Mitigations
 
See [1.4 source PR](https://github.com/Cray-HPE/csm-testing/pull/427) for details.
