### PR TITLE
CASMMON-250: Failed to start prometheus and grok-exporter

### DIFF
--- a/packages/node-image-pre-install-toolkit/base.packages
+++ b/packages/node-image-pre-install-toolkit/base.packages
@@ -10,8 +10,9 @@ ilorest=3.5.1-1
 metal-basecamp=1.2.4-1
 metal-ipxe=2.2.14-1
 metal-net-scripts=0.0.2-1
-pit-init=1.2.38-1
+pit-init=1.2.43-1
 pit-nexus=1.2.1-1
+pit-observability=1.0.6-1
 
 # SUSE Packages
 acl=2.2.52-4.3.1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMMON-250
- Requires: https://github.com/Cray-HPE/pit-observability/pull/5
- Relates to: #62 #60 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Do not `restart` the services, they operate with better success if they're `start`ed. This stops them for consistency, and then enables and starts them in one call.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
