### PR TITLE
CASMPET-5081 COS 2.5

### DIFF
--- a/packages/node-image-application/base.packages
+++ b/packages/node-image-application/base.packages
@@ -4,7 +4,7 @@
 # The version is the same version reported by the OS package manager (e.g. zypper).
 cfs-state-reporter=1.9.1-1
 cloud-init=21.4-1
-cray-auth-utils=0.3.1-2.4_20220907191100__gecf64bc
-cray-chrony-dracut=1.4.0-2.4_20220907211223__gf7f4743
-cray-heartbeat=1.8.2-2.4_3.11__g5712ad4.shasta
-spire-agent=0.12.2-2.4_20220907184947__ge83309b
+cray-auth-utils=0.4.1-2.5_20230113043005__g4aa0940
+cray-chrony-dracut=1.5.0-2.5_20230112202042__g70be251
+cray-heartbeat=1.9.1-2.5_1.2__gcf13165.shasta
+spire-agent=0.12.2-2.5_20230113021328__g48e293b

--- a/packages/node-image-compute/base.packages
+++ b/packages/node-image-compute/base.packages
@@ -34,34 +34,34 @@ typelib-1_0-Gtk-3_0=3.24.34-150400.3.3.1
 # - cray-systemd-presets                :
 # - cray-udev-network-cn                : Provides udev rules for network interfaces
 
-cray-auth-utils=0.3.1-2.4_20220907191100__gecf64bc
-cray-ckdump-helper=2.11.2-2.4_20220907192738__g2f4338a
-cray-chrony-dracut=1.4.0-2.4_20220907211223__gf7f4743
-cray-heartbeat=1.8.2-2.4_4.20__g5712ad4.shasta
-cray-hugepage-setup=0.6.1-2.4_20220907195721__g8a72bcc
-cray-network-dracut=1.3.1-2.4_20220907212221__ga511757
-cray-power-button=1.4.1-2.4_20220907233542__g35e8b4a
-cray-system-files=1.13.5-2.4_20220927102737__g81928fa
-cray-system-setup-scripts=1.3.3-2.4_20221215171734__gf3a8090
-cray-systemd-presets=1.6.1-2.4_20220907233542__gf8b34cc
-cray-udev-network-cn=1.6.18-2.4_20221025121011__ga8be192
-spire-agent=0.12.2-2.4_20220907184947__ge83309b
+cray-auth-utils=0.4.1-2.5_20230113043005__g4aa0940
+cray-ckdump-helper=2.12.1-2.5_20230112235926__g9e95309
+cray-chrony-dracut=1.5.0-2.5_20230112202042__g70be251
+cray-heartbeat=1.9.1-2.5_1.2__gcf13165.shasta
+cray-hugepage-setup=0.7.1-2.5_20230113063638__g3e2f155
+cray-network-dracut=1.4.0-2.5_20230113063048__gc9eac23
+cray-power-button=1.5.2-2.5_20230113092552__g0fcacce
+cray-system-files=1.14.5-2.5_20230113092927__g8fffb85
+cray-system-setup-scripts=1.4.3-2.5_20230113142817__ge0ef7dd
+cray-systemd-presets=1.7.3-2.5_20230113091846__g4a496ef
+cray-udev-network-cn=1.7.12-2.5_20230113033545__g737c32a
+spire-agent=0.12.2-2.5_20230113021328__g48e293b
 
 # COS SHASTA-OS packages
 # - cray-cos-release                    : Installed cle and cos release files.
 # - cray-low-noise-mode                 : Hardware optimization
-cray-cos-release=1.2.1-2.4_20221201073039__g029ecdf
-cray-low-noise-mode=1.2.3-2.4_20220907223914__gb6477c9
+cray-cos-release=1.3.1-2.5_20230113051708__g2c3f0bb
+cray-low-noise-mode=1.3.3-2.5_20230113084748__g7892358
 
 # COS SHASTA-3RD Packages
 # - acpid                               :
 # - cray-libhugetlbfs                   :
 # - cray-libhugetlbfs-devel             :
 # - cray-rasdaemon                      :
-acpid=2.0.31-1.1_2.4_20220907164401__g5cfe682
-cray-libhugetlbfs=2.20_2.1.29-2.4_3.13__g05da5a8.shasta
-cray-libhugetlbfs-devel=2.20_2.1.29-2.4_3.13__g05da5a8.shasta
-cray-rasdaemon=0.6.8-3_2.4_20220907184629__gdb74487
+acpid=2.0.31-1.1_2.5_20230113012845__g40880b3
+cray-libhugetlbfs=2.20_2.1.28-2.5_1.2__g814a27a.shasta
+cray-libhugetlbfs-devel=2.20_2.1.28-2.5_1.2__g814a27a.shasta
+cray-rasdaemon=0.6.8-3_2.5_20230112191741__g9c01752
 
 # GPU Support Packages
 autoconf=2.69-1.445

--- a/packages/node-image-ncn-common/base.packages
+++ b/packages/node-image-ncn-common/base.packages
@@ -56,10 +56,10 @@ xfsdump=3.1.6-1.30
 # - cray-auth-utils                     :
 # - cray-heartbeat                      : Serves the heartbeat read by HMS
 # - spire-agent                         :
-cray-auth-utils=0.3.1-2.4_20220805020628__ga82f924
-cray-power-button=1.4.0-2.4_20220805065637__gabaf78c
-cray-heartbeat=1.8.2-2.4_3.11__g5712ad4.shasta
-spire-agent=0.12.2-2.4_20220805014214__gd8c3376
+cray-auth-utils=0.4.1-2.5_20230113043005__g4aa0940
+cray-power-button=1.5.2-2.5_20230113081448__g0fcacce
+cray-heartbeat=1.9.1-2.5_1.2__gcf13165.shasta
+spire-agent=0.12.2-2.5_20230112214220__g48e293b
 
 # CMS Team
 cfs-debugger=1.3.0-1

--- a/repos/compute.template.repos
+++ b/repos/compute.template.repos
@@ -1,3 +1,3 @@
 # COS
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.4/sle15_sp4_cn?auth=basic               cray-cos-sle-15sp4-2.4-SHASTA-OS-cos-cn               --no-gpgcheck -p 79                   cray/cos/slj-15sp4-2.4-cn
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.5/sle15_sp4_cn?auth=basic               cray-cos-sle-15sp4-2.5-SHASTA-OS-cos-cn               --no-gpgcheck -p 79                   cray/cos/slj-15sp4-2.5-cn
 

--- a/repos/cray.template.repos
+++ b/repos/cray.template.repos
@@ -7,9 +7,7 @@ https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifac
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sat-rpms/hpe/stable/sle-15sp3?auth=basic                                                                                                                                      cray-algol60-sat-rpms-stable-sle-15sp3            --no-gpgcheck -p 88                   cray/sat/sle-15sp3
 
 # COS
-# NOTE: Includes SP3 with an older priority because cray-heartbeat isn't built for SP4 (yet - SKERN-7383)
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.4/sle15_sp3_ncn?auth=basic                                              cray-cos-sle-15sp3-2.4-SHASTA-OS-cos-ncn          --no-gpgcheck -p 90                   cray/cos/sle-15sp3
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.4/sle15_sp4_ncn?auth=basic                                              cray-cos-sle-15sp4-2.4-SHASTA-OS-cos-ncn          --no-gpgcheck -p 89                   cray/cos/sle-15sp4
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/cos-rpm-stable-local/release/cos-2.5/sle15_sp4_ncn?auth=basic                                              cray-cos-sle-15sp4-2.5-SHASTA-OS-cos-ncn          --no-gpgcheck -p 89                   cray/cos/sle-15sp4
 
 # SDU
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/dst-rpm-mirror/sdu-rpm-stable-local/release/img_oci-shasta-2.1/sle15_sp3_ncn?auth=basic                                   sdu-rpm-stable-local                              --no-gpgcheck -p 89                  cray/sdu/sle-15-sp3


### PR DESCRIPTION
Brings in COS 2.5, and does not upgrade `spire-agent`.