### PR TITLE
CASMPET-5081 COS 2.5 with spire 0.12.2

### DIFF
--- a/packages/node-image-application/base.packages
+++ b/packages/node-image-application/base.packages
@@ -7,4 +7,4 @@ cloud-init=21.4-1
 cray-auth-utils=0.4.1-2.5_20230113043005__g4aa0940
 cray-chrony-dracut=1.5.0-2.5_20230112202042__g70be251
 cray-heartbeat=1.9.1-2.5_1.2__gcf13165.shasta
-spire-agent=1.4.0-2.5_20230117111813__gc07bb77
+spire-agent=0.12.2-2.5_20230113021328__g48e293b

--- a/packages/node-image-compute/base.packages
+++ b/packages/node-image-compute/base.packages
@@ -45,7 +45,7 @@ cray-system-files=1.14.5-2.5_20230113092927__g8fffb85
 cray-system-setup-scripts=1.4.3-2.5_20230113142817__ge0ef7dd
 cray-systemd-presets=1.7.3-2.5_20230113091846__g4a496ef
 cray-udev-network-cn=1.7.12-2.5_20230113033545__g737c32a
-spire-agent=1.4.0-2.5_20230117111813__gc07bb77
+spire-agent=0.12.2-2.5_20230113021328__g48e293b
 
 # COS SHASTA-OS packages
 # - cray-cos-release                    : Installed cle and cos release files.

--- a/packages/node-image-ncn-common/base.packages
+++ b/packages/node-image-ncn-common/base.packages
@@ -59,7 +59,7 @@ xfsdump=3.1.6-1.30
 cray-auth-utils=0.4.1-2.5_20230113043005__g4aa0940
 cray-power-button=1.5.2-2.5_20230113081448__g0fcacce
 cray-heartbeat=1.9.1-2.5_1.2__gcf13165.shasta
-spire-agent=1.4.0-2.5_20230117111813__gc07bb77
+spire-agent=0.12.2-2.5_20230112214220__g48e293b
 
 # CMS Team
 cfs-debugger=1.3.0-1


### PR DESCRIPTION
Brings in COS 2.5, and does not upgrade `spire-agent`.

This is amending the PR that already merged: https://github.com/Cray-HPE/csm-rpms/pull/701