### PR TITLE
MTL-1476 New `cray-site-init`

### DIFF
--- a/packages/node-image-pre-install-toolkit/base.packages
+++ b/packages/node-image-pre-install-toolkit/base.packages
@@ -5,7 +5,7 @@
 
 # CSM Packages
 canu=1.6.28-1
-cray-site-init=1.29.1-1
+cray-site-init=1.30.0-1
 ilorest=3.5.1-1
 metal-basecamp=1.2.4-1
 metal-ipxe=2.2.14-1


### PR DESCRIPTION
Brings in newer `write-livecd.sh` script with support for the new ISO.
