### PR TITLE
CASMINST-5861 - bump ceph version

### DIFF
--- a/packages/node-image-ncn-common/base.packages
+++ b/packages/node-image-ncn-common/base.packages
@@ -5,7 +5,7 @@
 amsd=2.4.1-1571.4.sles15
 apparmor-profiles=3.0.4-150400.5.3.1
 aws-cli=1.24.4-150200.30.8.1
-ceph-common>=17.2.3
+ceph-common>=17.2.5
 cloud-init-config-suse=21.4-1
 cloud-init-doc=21.4-1
 cloud-init=21.4-1

--- a/packages/node-image-storage-ceph/base.packages
+++ b/packages/node-image-storage-ceph/base.packages
@@ -2,5 +2,5 @@
 # Format:
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
-cephadm>=17.2.3
+cephadm>=17.2.5
 libfmt8=8.0.1-150400.1.8


### PR DESCRIPTION
### Summary and Scope
upsteam stopped providing our currently installed version.
<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-5861
- Requires:
- Relates to:

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request


<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
