### PR TITLE
COS 2.5 align `cray-heartbeat` and `spire-agent`

### DIFF
--- a/packages/node-image-application/base.packages
+++ b/packages/node-image-application/base.packages
@@ -6,5 +6,5 @@ cfs-state-reporter=1.9.1-1
 cloud-init=21.4-1
 cray-auth-utils=0.4.1-2.5_20230113043005__g4aa0940
 cray-chrony-dracut=1.5.0-2.5_20230112202042__g70be251
-cray-heartbeat=1.9.1-2.5_1.2__gcf13165.shasta
-spire-agent=0.12.2-2.5_20230113021328__g48e293b
+cray-heartbeat=1.9.1-2.5_1.3__gcf13165.shasta
+spire-agent=0.12.2-2.5_20230119160451__g4d5646c

--- a/packages/node-image-compute/base.packages
+++ b/packages/node-image-compute/base.packages
@@ -37,7 +37,7 @@ typelib-1_0-Gtk-3_0=3.24.34-150400.3.3.1
 cray-auth-utils=0.4.1-2.5_20230113043005__g4aa0940
 cray-ckdump-helper=2.12.1-2.5_20230112235926__g9e95309
 cray-chrony-dracut=1.5.0-2.5_20230112202042__g70be251
-cray-heartbeat=1.9.1-2.5_1.2__gcf13165.shasta
+cray-heartbeat=1.9.1-2.5_1.3__gcf13165.shasta
 cray-hugepage-setup=0.7.1-2.5_20230113063638__g3e2f155
 cray-network-dracut=1.4.0-2.5_20230113063048__gc9eac23
 cray-power-button=1.5.2-2.5_20230113092552__g0fcacce
@@ -45,7 +45,7 @@ cray-system-files=1.14.5-2.5_20230113092927__g8fffb85
 cray-system-setup-scripts=1.4.3-2.5_20230113142817__ge0ef7dd
 cray-systemd-presets=1.7.3-2.5_20230113091846__g4a496ef
 cray-udev-network-cn=1.7.12-2.5_20230113033545__g737c32a
-spire-agent=0.12.2-2.5_20230113021328__g48e293b
+spire-agent=0.12.2-2.5_20230119160451__g4d5646c
 
 # COS SHASTA-OS packages
 # - cray-cos-release                    : Installed cle and cos release files.

--- a/packages/node-image-ncn-common/base.packages
+++ b/packages/node-image-ncn-common/base.packages
@@ -59,7 +59,7 @@ xfsdump=3.1.6-1.30
 cray-auth-utils=0.4.1-2.5_20230113043005__g4aa0940
 cray-power-button=1.5.2-2.5_20230113081448__g0fcacce
 cray-heartbeat=1.9.1-2.5_1.2__gcf13165.shasta
-spire-agent=0.12.2-2.5_20230112214220__g48e293b
+spire-agent=0.12.2-2.5_20230119160451__g4d5646c
 
 # CMS Team
 cfs-debugger=1.3.0-1


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #706 

#### Issue Type

<!--- Delete un-needed bullets -->

<!--- words; describe what this change is and what it is for. -->
`spire-agent` was rebuilt, the content is the same. This `spire-agent` change just aligns what's installed to what COS inventory says is current.

This found an update for `cray-heartbeat` for application and compute, the commit hash is the same.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
