### PR TITLE
CASMINST-5874: Update Goss tests for CRUS removal

### DIFF
--- a/packages/node-image-ncn-common/base.packages
+++ b/packages/node-image-ncn-common/base.packages
@@ -69,7 +69,7 @@ cfs-trust=1.6.3-1
 # CSM Team
 cray-kubectl-hns-plugin=1.0.1-1
 cray-kubectl-kubelogin-plugin=1.25.2-1
-goss-servers=1.16.2-1
+goss-servers=1.16.4-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.4.5-1
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMINST-5874](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5874)
- Relates to: [CASMCMS-8396](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8396)
- [csm PR](https://github.com/Cray-HPE/csm/pull/1728)

#### Issue Type

- RFE Pull Request

Update Goss tests to version modified to handle removed CRUS service.

See [source PR](https://github.com/Cray-HPE/csm-testing/pull/434) for details.

### Risks and Mitigations
 
Without this change, one Goss test will fail after CRUS is removed.
