### PR TITLE
CASMCMS-8397: Remove CRUS tests from cmsdev tool

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.10.0-1
+cray-cmstools-crayctldeploy=1.11.0-1
 platform-utils=1.4.3-1
 
 # DVS


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMCMS-8397](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8397)
- Relates to: [CASMCMS-8396](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8396)
- [csm PR](https://github.com/Cray-HPE/csm/pull/1733)

#### Issue Type

- RFE Pull Request

Update cmsdev test tool to remove CRUS test.

### Risks and Mitigations
 
Without this change, the cmsdev test tool will report errors during CSM health validation.
