### PR TITLE
CASMCMS-8399: Remove CRUS from Cray CLI

### DIFF
--- a/packages/node-image-base/base.packages
+++ b/packages/node-image-base/base.packages
@@ -120,7 +120,7 @@ zsh=5.6-7.5.1
 
 # CSM Team
 csm-node-identity=1.0.20-1
-craycli=0.67.0-1
+craycli=0.70.0-1
 
 # Metal Team
 kernel-default=5.14.21-150400.24.38.1.25440.1.PTF.1204911


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMCMS-8399](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8399)
- Relates to: [CASMCMS-8396](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8396)
- [csm manifest PR](https://github.com/Cray-HPE/csm/pull/1754)

#### Issue Type

- RFE Pull Request

Remove CRUS from the Cray CLI.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)

### Risks and Mitigations
 
Low risk. And since the tickets to remove CRUS have already merged, leaving it in the CLI is a bold move.