### PR TITLE
CASMCMS-8301: Update craycli to 0.68.0 for new BOS fields 91.4)

### DIFF
--- a/packages/node-image-base/base.packages
+++ b/packages/node-image-base/base.packages
@@ -120,7 +120,7 @@ zsh=5.6-7.5.1
 
 # CSM Team
 csm-node-identity=1.0.20-1
-craycli=0.67.0-1
+craycli=0.68.0-1
 
 # Metal Team
 kernel-default=5.14.21-150400.24.38.1.25440.1.PTF.1204911


### PR DESCRIPTION
## Summary and Scope

Updates the craycli to include the BOS clear-state option.  Also pulls in some linting changes.

## Issues and Related PR

* Resolves CASMCMS-8301

## Testing

See craycli PRs for testing info

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

