### PR TITLE
hpe-csm-scripts RPM: set-bmc-ntp-dns: Improved arg parsing

### DIFF
--- a/packages/node-image-non-compute-common/base.packages
+++ b/packages/node-image-non-compute-common/base.packages
@@ -155,7 +155,7 @@ craycli=0.63.0-1
 csm-node-identity=1.0.18-1
 goss-servers=1.14.60-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
-hpe-csm-scripts=0.3.0-1
+hpe-csm-scripts=0.3.1-1
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 
 # Metal


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMINST-2557](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-2557)
- [main manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/741)
- [1.4 manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/742)
- [csm main manifest PR](https://github.com/Cray-HPE/csm/pull/1825)
- [csm 1.4 manifest PR](https://github.com/Cray-HPE/csm/pull/1826)
- [csm 1.3 manifest PR](https://github.com/Cray-HPE/csm/pull/1827)

#### Issue Type

- Bugfix Pull Request

Fixes some errors and inconsistencies with the argument parsing of the set-bmc-ntp-dns script. Backwards compatible except for fixing previous bad behavior.

See [source PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/39) for details.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)

### Risks and Mitigations

Low risk -- no change to the script logic itself, only to its argument parsing and validation. 
