### PR TITLE
VSHA-536 Add `virtio` support

### DIFF
--- a/packages/node-image-kubernetes/metal.packages
+++ b/packages/node-image-kubernetes/metal.packages
@@ -2,5 +2,5 @@
 # Format:
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
-dracut-metal-dmk8s=2.0.6-1
-dracut-metal-luksetcd=2.0.5-1
+dracut-metal-dmk8s=2.1.0-1
+dracut-metal-luksetcd=2.1.0-1

--- a/packages/node-image-ncn-common/metal.packages
+++ b/packages/node-image-ncn-common/metal.packages
@@ -2,6 +2,6 @@
 # Format:
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
-dracut-metal-mdsquash=2.3.1-1
+dracut-metal-mdsquash=2.4.0-1
 haproxy=2.0.14-bp152.1.1
 keepalived=2.0.19-bp152.1.9


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: VSHA-536

Brings in:
- https://github.com/Cray-HPE/dracut-metal-mdsquash/pull/56
- https://github.com/Cray-HPE/dracut-metal-luksetcd/pull/42
- https://github.com/Cray-HPE/dracut-metal-dmk8s/pull/33

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This adds `virtio` support for supporting Google standard-disks as well as bugfixes for edge cases.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
