### PR TITLE
MTL-2097

### DIFF
--- a/packages/node-image-pre-install-toolkit/base.packages
+++ b/packages/node-image-pre-install-toolkit/base.packages
@@ -5,7 +5,7 @@
 
 # CSM Packages
 canu=1.6.35-1
-cray-site-init=1.30.0-1
+cray-site-init=1.30.3-1
 ilorest=3.5.1-1
 metal-basecamp=1.2.4-1
 metal-ipxe=2.2.14-1


### PR DESCRIPTION
CSM 1.4 and CSM 1.5 use the same version of CSI.

This just brings in:
- (MTL-2097) https://github.com/Cray-HPE/cray-site-init/pull/289
- (CVE) https://github.com/Cray-HPE/cray-site-init/pull/287
- (CVE) https://github.com/Cray-HPE/cray-site-init/pull/285
- (CVE) https://github.com/Cray-HPE/cray-site-init/pull/286
- (CVE) https://github.com/Cray-HPE/cray-site-init/pull/291
