### PR TITLE
CASMCMS-8479/CASMCMS-8480: cmsdev: Add feature to list available tests; fix minor bug

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.10.2-1
+cray-cmstools-crayctldeploy=1.10.3-1
 platform-utils=1.4.3-1
 
 # DVS


### PR DESCRIPTION
## Summary and Scope

To help @mtupitsyn add cmsdev to Goss, this adds a feature to cmsdev that lists the available tests it can run.
In addition, a null pointer exception is fixed (but this is only hit when using cmsdev in an unadvertised way and before CSM is deployed -- so not a critical problem).

See source PRs for details.

## Issues and Related PRs

- [CASMCMS-8479 source PR](https://github.com/Cray-HPE/cms-tools/pull/76)
- [CASMCMS-8480 source PR](https://github.com/Cray-HPE/cms-tools/pull/77)
- Resolves [CASMCMS-8479](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8479)
- Resolves [CASMCMS-8480](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8480)
- [csm 1.4 manifest PR](https://github.com/Cray-HPE/csm/pull/1993)
- [csm main manifest PR](https://github.com/Cray-HPE/csm/pull/1994)
- [csm-rpms main manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/792)

## Testing

See source PRs.

## Risks and Mitigations

Low risk. No changes to the tests themselves. New code will only be exercised by Goss at this point.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
