### PR TITLE
CASMCMS-8482: cmsdev repository cleanup (remove binary from repo, stop building SP3 RPM)

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.10.3-1
+cray-cmstools-crayctldeploy=1.10.4-1
 platform-utils=1.4.3-1
 
 # DVS


### PR DESCRIPTION
### Summary and Scope

Functionally no change to this RPM (just backend changes to the build process and the repo). But I'd rather keep the manifest at the latest version in this case, so that if we need to make later changes, it will be on top of this version.

See [source PR](https://github.com/Cray-HPE/cms-tools/pull/80) for details.

[csm-rpms main manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/795)

This is going into the csm manifest repo as part of these combo manifest PRs:
https://github.com/Cray-HPE/csm/pull/1993
https://github.com/Cray-HPE/csm/pull/1994
