### PR TITLE
CASMCMS-8482: cmsdev repository cleanup (remove binary from repo, stop building SP3 RPM)

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.11.2-1
+cray-cmstools-crayctldeploy=1.11.3-1
 platform-utils=1.5.1-1
 
 # DVS


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/csm-rpms/pull/794
