### PR TITLE
CASMCMS-8481: Make BOS V2 the default for cray cli BOS commands

### DIFF
--- a/packages/node-image-base/base.packages
+++ b/packages/node-image-base/base.packages
@@ -121,7 +121,7 @@ zsh=5.6-7.5.1
 
 # CSM Team
 csm-node-identity=1.0.20-1
-craycli=0.70.0-1
+craycli=0.71.0-1
 
 # Metal Team
 kernel-default=5.14.21-150400.24.46.1


### PR DESCRIPTION
### Summary and Scope

This new craycli RPM makes BOS V2 the default version used when a 'cray bos <command>' is issued without specifying a version.



- Relates to: CASMCMS-8481

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.
I'm changing the default version of BOS used when the cray CLI calls BOS. There is some risk if scripters called cray bos without specifying a version which is contraindicated in the BOS documentation.
-->
