### PR TITLE
CASMCMS-8485: Remove unused outdated non-test content from cmsdev

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.11.3-1
+cray-cmstools-crayctldeploy=1.11.4-1
 platform-utils=1.5.1-1
 
 # DVS


### PR DESCRIPTION
## Summary and Scope

This PR removes sections of the cmsdev tool which have not been updated or used in years. The features being removed were never documented to customers. Nothing that is documented or used is altered or removed.

## Issues and Related PRs

* [csm manifest PR](https://github.com/Cray-HPE/csm/pull/2015)
* [CASMCMS-8485](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8485)
* [Source PR:](https://github.com/Cray-HPE/cms-tools/pull/83)

## Testing

See source PR for details.

## Risks and Mitigations

Very low risk. Even so, because it is getting late in the CSM 1.4 release, I decided to only make this change for CSM 1.5.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
