### PR TITLE
CASMNET-2056 Bump canu to 1.7.0

### DIFF
--- a/packages/node-image-pre-install-toolkit/base.packages
+++ b/packages/node-image-pre-install-toolkit/base.packages
@@ -4,7 +4,7 @@
 # The version is the same version reported by the OS package manager (e.g. zypper).
 
 # CSM Packages
-canu=1.6.35-1
+canu=1.7.0-1
 cray-site-init=1.31.1-1
 ilorest=3.5.1-1
 metal-basecamp=1.2.5-1


### PR DESCRIPTION
Include CANU 1.7.0 in CSM base packages.  Includes dozens of bugfixes as well as customer acceptance required changes.

- Fixes: JIRA (CASMNET-2056)

#### Issue Type

- RFE Pull Request

Full gamut of changes at:  https://github.com/Cray-HPE/canu/releases/tag/1.7.0

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system
- [ ] I tested this on a vagrant system
- [ ] I tested this on a vshasta system
