### PR TITLE
CASMNET-2056 Canu-1.7.0-1.3

### DIFF
--- a/packages/cray-pre-install-toolkit/base.packages
+++ b/packages/cray-pre-install-toolkit/base.packages
@@ -5,7 +5,7 @@
 
 # CSM Packages
 apache2=2.4.51-150200.3.48.1
-canu=1.6.20-1
+canu=1.7.0-1
 craycli=0.63.0-1
 dnsmasq=2.86-150100.7.20.1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77


### PR DESCRIPTION
Include CANU 1.7.0 in CSM base packages.  Includes dozens of bugfixes as well as customer acceptance required changes.

- Fixes: JIRA (CASMNET-2056)

#### Issue Type

- RFE Pull Request

Full gamut of changes at:  https://github.com/Cray-HPE/canu/releases/tag/1.7.0

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system
- [ ] I tested this on a vagrant system
- [ ] I tested this on a vshasta system
