### PR TITLE
CASMCMS-8495: cmsdev: Update default CLI BOS version to v2

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.11.4-1
+cray-cmstools-crayctldeploy=1.11.5-1
 platform-utils=1.5.1-1
 
 # DVS


### PR DESCRIPTION
## Summary and Scope

Update cmsdev test tool to reflect change in Cray CLI defaults. See [source PR](https://github.com/Cray-HPE/cms-tools/pull/87) for details.

## Issues and Related PRs

- [Source PR](https://github.com/Cray-HPE/cms-tools/pull/87)
- Test failures caused by [CASMCMS-8481](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8481)
- Resolves [CASMCMS-8495](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8495)
- [csm main manifest PR](https://github.com/Cray-HPE/csm/pull/2043)
- [csm 1.4 manifest PR](https://github.com/Cray-HPE/csm/pull/2044)
- [csm-rpms 1.4 manifest PR](https://github.com/Cray-HPE/csm-rpms/pull/805)

## Testing

See [source PR](https://github.com/Cray-HPE/cms-tools/pull/87) for details.

## Risks and Mitigations

Without this change, the cmsdev bos test will fail on all CSM 1.4+ systems.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
