### PR TITLE
CASMCMS-8495: cmsdev: Update default CLI BOS version to v2

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.10.4-1
+cray-cmstools-crayctldeploy=1.10.5-1
 platform-utils=1.4.3-1
 
 # DVS


### PR DESCRIPTION
1.4 backport of https://github.com/Cray-HPE/csm-rpms/pull/804