### PR TITLE
CASMINST-6100 Change to new HPE SPP mirror

### DIFF
--- a/packages/node-image-ncn-common/base.packages
+++ b/packages/node-image-ncn-common/base.packages
@@ -2,7 +2,7 @@
 # Format:
 #   package_name=version
 # The version is the same version reported by the OS package manager (e.g. zypper).
-amsd=2.4.1-1571.4.sles15
+amsd=2.7.0-1724.3.sles15
 apparmor-profiles=3.0.4-150400.5.3.1
 aws-cli=1.24.4-150200.30.8.1
 ceph-common>=17.2.5

--- a/repos/hpe.template.repos
+++ b/repos/hpe.template.repos
@@ -1,3 +1,4 @@
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/hpe-mirror-mlnx_ofed_cx4plus/SLES15-SP4/x86_64/5.7-1.0.2.0?auth=basic     hpe-mirror-mlnx_ofed_cx4plus --no-gpgcheck -p 90    SLES15-SP4/x86_64/5.7-1.0.2.0
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/hpe-mirror-spp/SLES15/x86_64/current?auth=basic                           hpe-mirror-spp               --no-gpgcheck -p 99    SLES15/x86_64/current
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/hpe-mirror-spp-gen10/SUSE/SLES15-SP4/x86_64/current?auth=basic                           hpe-mirror-spp-gen10               --no-gpgcheck -p 99    SLES15-SP4/x86_64/current
+#https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/hpe-mirror-spp-gen11/SUSE/SLES15-SP4/x86_64/current?auth=basic                           hpe-mirror-spp-gen11               --no-gpgcheck -p 99    SLES15-SP4/x86_64/current
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-6100

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
The hpe-spp mirror is no longer updated, switch to the new hpe-spp-gen10 mirror (and add gen11 but comment it out).

Also update `amsd`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
