### PR TITLE
CASMCMS-8496/CASMCMS-8513/CASMCMS-8514: cmsdev: Test fixes and improvements

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.11.7-1
+cray-cmstools-crayctldeploy=1.11.8-1
 platform-utils=1.5.2-1
 
 # DVS


### PR DESCRIPTION
## Summary and Scope

Fixes bugs causing the BOS and VCS tests to fail on CSM 1.5. Simplifies the BOS test to avoid false failures. Reduces redundancy in test output.

## Issues and Related PRs

- [CASMCMS-8496 source PR](https://github.com/Cray-HPE/cms-tools/pull/93)
- [CASMCMS-8513 source PR](https://github.com/Cray-HPE/cms-tools/pull/96/)
- [CASMCMS-8514 source PR](https://github.com/Cray-HPE/cms-tools/pull/97/)
- Resolves [CASMCMS-8496](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8496), [CASMCMS-8513](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8513), [CASMCMS-8514](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8514), [CASMTRIAGE-5129](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5129), [CASMTRIAGE-5130](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5130)
- [csm main manifest PR](https://github.com/Cray-HPE/csm/pull/2081)
- [csm 1.4 manifest backport PR](https://github.com/Cray-HPE/csm/pull/2080) -- only contains part of [CASMCMS-8514](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8514) changes.
- [csm-rpms 1.4 manifest backport PR](https://github.com/Cray-HPE/csm-rpms/pull/817) -- only contains part of [CASMCMS-8514](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8514) changes.

## Testing

See source PRs for details.

## Risks and Mitigations

Low risk. Without these, some tests will always fail on CSM 1.5.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
