### PR TITLE
MTL-2138 Pull in OOB QLogic FastLinq Driver

### DIFF
--- a/packages/node-image-base/base.packages
+++ b/packages/node-image-base/base.packages
@@ -134,6 +134,7 @@ kernel-syms=5.14.21-150400.24.55.1
 kernel-mft-mlnx-kmp-default=4.21.0_k5.14.21_150400.22-1.sles15sp4
 # DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"
 mft=4.21.0-99
+qlgc-fastlinq-kmp-default=8.72.1.0_k5.14.21_150400.22-1.sles15sp4
 
 # Python3 RPM Packages
 # These support applications that do not install into virtualenvs, and that need airgap support.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2138
- Relates to: CASMTRIAGE-5033

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The 8.72 QLogic FastLinq driver will help protect against kernel panics seen by CASMTRIAGE-5033's root cause.

This does not fix the root cause of CASMTRIAGE-5033, loss of connectivity is still expected.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
