### PR TITLE
fake conntrack cleanup

### DIFF
--- a/scripts/rpm-functions.sh
+++ b/scripts/rpm-functions.sh
@@ -72,7 +72,7 @@ function add-fake-conntrack {
     mv /tmp/conntrack/* /var/local-repos/conntrack/
     createrepo /var/local-repos/conntrack
     zypper -n addrepo --refresh --no-gpgcheck /var/local-repos/conntrack buildonly-local-conntrack
-    zypper --non-interactive remove rpm-build createrepo_c
+    zypper --non-interactive remove --clean-deps rpm-build createrepo_c
 }
 
 function remove-comments-and-empty-lines() {
@@ -84,7 +84,7 @@ function setup-csm-rpms {
 }
 
 function cleanup-csm-rpms {
-    zypper --non-interactive remove gettext-tools gawk jq
+    zypper --non-interactive remove gettext-tools gawk jq || echo 'Ignoring errors'
 }
 
 function zypper-add-repos() {
@@ -139,7 +139,8 @@ function setup-package-repos() {
   add-google-repos
   add-hpe-repos
   add-suse-repos
-  # fake-conntrack necessary for kubernetes; must run after all repos are setup.
+
+  # fake-conntrack necessary for kubernetes on SUSE distros; must run after all repos are setup.
   add-fake-conntrack
   zypper lr -e /tmp/repos.repos
   cat /tmp/repos.repos
@@ -275,7 +276,7 @@ function get-current-package-list() {
   local inventory_file=$(mktemp)
   local output_path="$1"
   local packages="$2"
-  local base_inventory="$3"
+  local base_inventory="${3:-''}"
 
   if [[ ! -z "$base_inventory" ]]; then
     local base_arg="-b $base_inventory"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
When the fake conntrack RPM is setup, `rpmbuild` and `createrepo_c` are needed temporarily. These two packages bring in several dependencies that do not get cleaned up.

Clean these up by using `--clean-deps` during their removal.

Before:
```bash
    qemu.hypervisor: The following 37 NEW packages are going to be installed:
    qemu.hypervisor:   binutils bzip2 cpp cpp7 createrepo_c dwz gcc gcc7 gettext-tools glibc-devel glibc-locale glibc-locale-base libasan4 libatomic1 libcilkrts5 libcreaterepo_c0 libctf-nobfd0 libctf0 libgomp1 libisl15 libitm1 liblsan0 libmodulemd2 libmpc3 libmpfr6 libmpx2 libmpxwrappers2 libtsan0 libubsan0 libxcrypt-devel libyaml-0-2 linux-glibc-devel make patch rpm-build tar xz
```
```
    qemu.hypervisor: The following 2 packages are going to be REMOVED:
    qemu.hypervisor:   createrepo_c rpm-build
```

After:
```bash
    qemu.hypervisor: The following 37 NEW packages are going to be installed:
    qemu.hypervisor:   binutils bzip2 cpp cpp7 createrepo_c dwz gcc gcc7 gettext-tools glibc-devel glibc-locale glibc-locale-base libasan4 libatomic1 libcilkrts5 libcreaterepo_c0 libctf-nobfd0 libctf0 libgomp1 libisl15 libitm1 liblsan0 libmodulemd2 libmpc3 libmpfr6 libmpx2 libmpxwrappers2 libtsan0 libubsan0 libxcrypt-devel libyaml-0-2 linux-glibc-devel make patch rpm-build tar xz
```

```
    qemu.hypervisor: The following 33 packages are going to be REMOVED:
    qemu.hypervisor:   binutils bzip2 cpp cpp7 createrepo_c dwz gcc gcc7 gettext-tools glibc-devel libasan4 libatomic1 libcilkrts5 libcreaterepo_c0 libctf-nobfd0 libctf0 libgomp1 libisl15 libitm1 liblsan0 libmodulemd2 libmpc3 libmpfr6 libmpx2 libmpxwrappers2 libtsan0 libubsan0 libxcrypt-devel libyaml-0-2 linux-glibc-devel make patch rpm-build
```

***NOTE*** This leaves ~5 packages behind, but it's still better then leaving 35!

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
