### PR TITLE
CASMCMS-8549: cmsdev: Add list of valid tests to --help output

### DIFF
--- a/packages/node-image-kubernetes/base.packages
+++ b/packages/node-image-kubernetes/base.packages
@@ -8,7 +8,7 @@ kubeadm=1.21.12-0
 kubelet=1.21.12-0
 
 # CSM
-cray-cmstools-crayctldeploy=1.11.9-1
+cray-cmstools-crayctldeploy=1.11.10-1
 platform-utils=1.5.2-1
 
 # DVS


### PR DESCRIPTION
## Summary and Scope

When helping NERSC last week, we noticed that the cmsdev test tool doesn't provide a list of valid tests to run when you ask it to show its usage message -- it is only visible when you specify an invalid test or omit the test argument. This changes that, so that you can get the information from the usage message itself.

No changes made to the tests themselves.

## Issues and Related PRs

- [Source PR](https://github.com/Cray-HPE/cms-tools/pull/102)
- [csm manifest PR](https://github.com/Cray-HPE/csm/pull/2137)
- Resolves [CASMCMS-8549](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8549)

## Testing

See source PR.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
